### PR TITLE
Fix travis badge and coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-service_name: travis-pro
+service_name: travis-ci

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/broadinstitute/agora.svg?branch=master)](https://travis-ci.com/broadinstitute/agora?branch=master)
+[![Build Status](https://travis-ci.org/broadinstitute/agora.svg?branch=master)](https://travis-ci.org/broadinstitute/agora?branch=master)
 [![Coverage Status](https://coveralls.io/repos/broadinstitute/agora/badge.svg?branch=master)](https://coveralls.io/r/broadinstitute/agora?branch=master)
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import org.scoverage.coveralls.CoverallsPlugin.CoverallsKeys._
 import sbtassembly.Plugin.AssemblyKeys._
 import sbtassembly.Plugin._
 import sbtrelease.ReleasePlugin._
@@ -65,8 +64,4 @@ val customMergeStrategy: String => MergeStrategy = {
 }
 
 mergeStrategy in assembly := customMergeStrategy
-
-Seq(CoverallsPlugin.singleProject: _*)
-
-coverallsServiceName := "travis-pro" 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,8 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
 


### PR DESCRIPTION
-Fixed travis badge in README.
-Updated scoverage and coveralls jars (only updated scoverage to 1.0.4 instead of 1.1.0 because 1.1.0 changed the way it looks for our source files and is breaking for obscure reasons)
-Removed some unused stuff in build.sbt (we don't need the key related stuff in there because we're not using travis pro and our coveralls key is in a travis environment variable, see https://github.com/scoverage/sbt-coveralls)