### PR TITLE
Add Request elements should not be optional.

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
@@ -26,13 +26,14 @@ object AgoraEntity {
     }
 
   def fromAgoraAddRequest(agoraAddRequest: AgoraAddRequest, createDate: Option[Date]) = {
-    new AgoraEntity(namespace = agoraAddRequest.namespace,
-                    name = agoraAddRequest.name,
-                    synopsis = agoraAddRequest.synopsis,
-                    documentation = agoraAddRequest.documentation,
-                    owner = agoraAddRequest.owner,
-                    createDate = createDate,
-                    payload = agoraAddRequest.payload)
+    new AgoraEntity(namespace = Option(agoraAddRequest.namespace),
+      name = Option(agoraAddRequest.name),
+      synopsis = Option(agoraAddRequest.synopsis),
+      documentation = Option(agoraAddRequest.documentation),
+      owner = Option(agoraAddRequest.owner),
+      createDate = createDate,
+      payload = Option(agoraAddRequest.payload)
+    )
   }
 
 }
@@ -41,7 +42,6 @@ object AgoraAddRequest {
   implicit val AgoraAddRequestUnmarshaller =
     Unmarshaller[AgoraAddRequest](`application/json`) {
       case HttpEntity.NonEmpty(contentType, data) ⇒ grater[AgoraAddRequest].fromJSON(data.asString)
-      case HttpEntity.Empty ⇒ new AgoraAddRequest()
     }
 
   implicit val AgoraAddRequestMarshaller =
@@ -71,15 +71,15 @@ case class AgoraEntity(@(ApiModelProperty@field)(required = true, value = "The n
 
 @ApiModel(value = "Request to add method")
 case class AgoraAddRequest(@(ApiModelProperty@field)(required = true, value = "The namespace to which the method belongs")
-                       namespace: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "The method name ")
-                       name: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "A short description of the method")
-                       synopsis: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "Method documentation")
-                       documentation: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "User who owns this method in the methods repo")
-                       owner: Option[String] = None, // TODO: remove (use authenticated user)
-                       @(ApiModelProperty@field)(required = true, value = "The method payload")
-                       payload: Option[String] = None
-                        )
+                           namespace: String,
+                           @(ApiModelProperty@field)(required = true, value = "The method name ")
+                           name: String,
+                           @(ApiModelProperty@field)(required = true, value = "A short description of the method")
+                           synopsis: String,
+                           @(ApiModelProperty@field)(required = true, value = "Method documentation")
+                           documentation: String,
+                           @(ApiModelProperty@field)(required = true, value = "User who owns this method in the methods repo")
+                           owner: String, // TODO: remove (use authenticated user)
+                           @(ApiModelProperty@field)(required = true, value = "The method payload")
+                           payload: String
+                            )

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/ApiServiceSpec.scala
@@ -31,12 +31,20 @@ class ApiServiceSpec extends FlatSpec with Matchers with Directives with Scalate
   val documentation = "This is the documentation"
   val owner = "bob the builder"
   val payload = "echo 'hello world'"
-  val testMethod = AgoraEntity(namespace = Option(namespace), name = Option(name))
+  val testEntity = AgoraEntity(namespace = Option(namespace), name = Option(name))
+  val testAddRequest = new AgoraAddRequest(
+    namespace = namespace,
+    name = name,
+    synopsis = synopsis,
+    documentation = documentation,
+    owner = owner,
+    payload = payload
+  )
   
   "Agora" should "return information about a method, including metadata " in {
     val testFixture = fixture
 
-    val insertedEntity = testFixture.agoraDao.insert(testMethod)
+    val insertedEntity = testFixture.agoraDao.insert(testEntity)
 
     Get(ApiUtil.Methods.withLeadingSlash + "/" + namespace + "/" + name + "/" + insertedEntity.id.get) ~> methodsService.queryRoute ~> check {
       responseAs[AgoraEntity] === insertedEntity
@@ -46,9 +54,7 @@ class ApiServiceSpec extends FlatSpec with Matchers with Directives with Scalate
   "Agora" should "create and return a method" in {
     val testFixture = fixture
 
-    val agoraAddRequest = new AgoraAddRequest()
-    
-    Post(ApiUtil.Methods.withLeadingSlash, marshal(testMethod)) ~> methodsService.postRoute ~> check {
+    Post(ApiUtil.Methods.withLeadingSlash, marshal(testAddRequest)) ~> methodsService.postRoute ~> check {
       val response = responseAs[AgoraEntity]
       response.namespace === namespace
       response.name === name


### PR DESCRIPTION
We created a separate data model for POST requests so users could not supply values for things we want to create ourselves (like ID).
We also don't want them able to OMIT things we require. Like name. Therefore removed Options from these fields.