### PR TITLE
Bt documentation test

### DIFF
--- a/src/test/resources/TESTMARKDOWN.md
+++ b/src/test/resources/TESTMARKDOWN.md
@@ -1,0 +1,52 @@
+Basic Text
+Here is some text that includes some "double quotes" and some 'single quotes' and some "combinations 'thereof'".
+It {(also) [includes]} <some\> /extra \special \ncharacters. Think \*they'll be ~ok\?
+!@#$%^&*,.?;:=/-+
+
+# Headings
+# The largest heading (an <h1> tag)
+## The second largest heading (an <h2> tag)
+### The third largest heading (an <h3> tag)
+#### The fourth largest heading (an <h4> tag)
+##### The fifth largest heading (an <h5> tag)
+###### The sixth largest heading (an <h6> tag)
+
+# Line Breaks
+Below is a line break
+=====
+
+# Block-Quotes
+> This is a blockquote. It "includes" some quotation marks.
+
+# Text Styling
+**This _is_ a string that combines both bolds and italics.**
+
+# Lists
+This is a nested list that combines both unordered and ordered list with multiple levels of indenture.
+1. Item 1
+  1. A corollary to the above item.
+  2. Yet another point to consider.
+2. Item 2
+  * A corollary that does not need to be ordered.
+    * This is indented four spaces, because it's two spaces further than the item above.
+    * You might want to consider making a new list.
+3. Item 3
+
+# Code Formatting
+Here is some text with `monospacing`, within which text appears `**AS**IS`.
+
+# Code Blocks
+```
+# Here is a block of code
+x = 0
+x = 2 + 2
+what is x
+```
+
+# Links
+Here is a regular link:
+Scala](http://www.scala-lang.org/)
+Here are some image links:
+[![Build Status](https://travis-ci.org/broadinstitute/agora.svg?branch=master)](https://travis-ci.org/broadinstitute/agora?branch=master)
+[![Coverage Status](https://coveralls.io/repos/broadinstitute/agora/badge.svg?branch=master)](https://coveralls.io/r/broadinstitute/agora?branch=master)
+

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -3,13 +3,20 @@ package org.broadinstitute.dsde.agora.server
 import org.broadinstitute.dsde.agora.server.model.{AgoraAddRequest, AgoraEntity}
 
 trait AgoraTestData {
-
+  def getBigDocumentation: String = {
+    // Read contents of a test markdown file into a single string.
+    val markdown = io.Source.fromFile("src/test/resources/TESTMARKDOWN.md").getLines() mkString "\n"
+    markdown * 7  // NB: File is 1.6 Kb, so 7* that is >10kb, our minimal required storage amount.
+  }
+  
   val namespace1 = "broad"
   val namespace2 = "hellbender"
   val name1 = "testMethod1"
   val name2 = "testMethod2"
   val synopsis = "This is a test method"
   val documentation = "This is the documentation"
+  // NB: save io by storing output.
+  val bigDocumentation: String = getBigDocumentation
   val owner1 = "bob"
   val owner2 = "dave"
   val payload = """task wc {
@@ -51,5 +58,14 @@ trait AgoraTestData {
     documentation = documentation,
     owner = owner1,
     payload = badPayload
+  )
+
+  val testAddRequestBigDoc = new AgoraAddRequest(
+    namespace = namespace1,
+    name = name1,
+    synopsis = synopsis,
+    documentation = bigDocumentation,
+    owner = owner1,
+    payload = payload
   )
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
@@ -23,5 +23,7 @@ class AgoraTestSuite extends Suites(new ApiServiceSpec, new MethodsDbTest) with 
   override def afterAll() {
     println("Stopping embedded mongo db instance.")
     mongoStop(mongoProps)
+    println("Stopping Agora web services.")
+    Agora.stop()
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -65,4 +65,10 @@ class ApiServiceSpec extends FlatSpec with Matchers with Directives with Scalate
     }
   }
 
+  "Agora" should "store 10kb of github markdown as method documentation and return it without alteration" in {
+    Post(ApiUtil.Methods.withLeadingSlash, marshal(testAddRequest)) ~> methodsService.postRoute ~> check {
+      val rawResponse = responseAs[String]
+      grater[AgoraEntity].fromJSON(rawResponse).documentation === bigDocumentation
+    }
+  }
 }


### PR DESCRIPTION
Added a test for successful storage of markdown in documentation
    
To satisfy DSDEEPB-46. Acceptance Criteria:

```
* There exists a metadata field which can accept a large (10KB) markdown representing tool documentation.
* There exists a unit test that validates that a 10kb string of github markdown is recovered without getting garbled
```

The metadata field exists. Here I'm adding the test. I made a little md file containing various markdown features.

I am concatenating that until it would be >10kb stored, and sending that through the webservice.
    
I am doing this the full way through the service, not just as a db test, because I want to make sure serialization/deserialization and spray marshalling etc. do not garble the string.

Only changed total testing time from 5s -> 6s

Also added Agora.stop() back to test suite cleanup.