### PR TITLE
Swagger updates to fix search in swaggerui

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,6 +14,6 @@ swagger {
   info = "Agora Methods Repository"
   license = "BSD"
   licenseUrl = "http://opensource.org/licenses/BSD-3-Clause"
-  swaggerVersion = "1.2"
+  swaggerVersion = "1.3"
   termsOfServiceUrl = "http://www.github.com/broadinstitute/agora"
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
@@ -49,38 +49,38 @@ object AgoraAddRequest {
 }
 
 @ApiModel(value = "Agora Method")
-case class AgoraEntity(@(ApiModelProperty@field)(required = true, value = "The namespace to which the method belongs")
+case class AgoraEntity(@(ApiModelProperty@field)(required = false, value = "The namespace to which the method belongs")
                        namespace: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "The method name ")
+                       @(ApiModelProperty@field)(required = false, value = "The method name ")
                        name: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "The method id")
+                       @(ApiModelProperty@field)(required = false, value = "The method id")
                        var id: Option[Int] = None,
-                       @(ApiModelProperty@field)(required = true, value = "A short description of the method")
+                       @(ApiModelProperty@field)(required = false, value = "A short description of the method")
                        synopsis: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "Method documentation")
+                       @(ApiModelProperty@field)(required = false, value = "Method documentation")
                        documentation: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "User who owns this method in the methods repo")
+                       @(ApiModelProperty@field)(required = false, value = "User who owns this method in the methods repo")
                        owner: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "The date the method was inserted in the methods repo")
+                       @(ApiModelProperty@field)(required = false, value = "The date the method was inserted in the methods repo")
                        createDate: Option[Date] = None,
-                       @(ApiModelProperty@field)(required = true, value = "The method payload")
+                       @(ApiModelProperty@field)(required = false, value = "The method payload")
                        payload: Option[String] = None
                         )
 
 @ApiModel(value = "Agora Search")
-case class AgoraSearch(@(ApiModelProperty@field)(required = true, value = "The namespace to which the method belongs")
+case class AgoraSearch(@(ApiModelProperty@field)(required = false, value = "The namespace to which the method belongs")
                        namespace: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "The method name ")
+                       @(ApiModelProperty@field)(required = false, value = "The method name ")
                        name: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "The method id")
+                       @(ApiModelProperty@field)(required = false, value = "The method id")
                        var id: Option[Int] = None,
-                       @(ApiModelProperty@field)(required = true, value = "User who owns this method in the methods repo")
+                       @(ApiModelProperty@field)(required = false, value = "User who owns this method in the methods repo")
                        owner: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "A short description of the method")
+                       @(ApiModelProperty@field)(required = false, value = "A short description of the method")
                        synopsis: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "Method documentation")
+                       @(ApiModelProperty@field)(required = false, value = "Method documentation")
                        documentation: Option[String] = None,
-                       @(ApiModelProperty@field)(required = true, value = "The method payload")
+                       @(ApiModelProperty@field)(required = false, value = "The method payload")
                        payload: Option[String] = None
                       )
 

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsService.scala
@@ -40,16 +40,17 @@ trait MethodsService extends HttpService with PerRequestCreator {
     nickname = "methods",
     httpMethod = "GET",
     produces = "application/json",
-    response = classOf[Seq[AgoraEntity]],
+    response = classOf[AgoraEntity],
+    responseContainer="Seq",
     notes = "API is rapidly changing.")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "namespace", required = true, dataType = "string", paramType = "path", value = "Namespace"),
-    new ApiImplicitParam(name = "name", required = true, dataType = "string", paramType = "path", value = "Name"),
-    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "Id"),
-    new ApiImplicitParam(name = "synopsis", required = true, dataType = "string", paramType = "path", value = "Synopsis"),
-    new ApiImplicitParam(name = "documentation", required = true, dataType = "string", paramType = "path", value = "Documentation"),
-    new ApiImplicitParam(name = "owner", required = true, dataType = "string", paramType = "path", value = "Owner"),
-    new ApiImplicitParam(name = "payload", required = true, dataType = "string", paramType = "path", value = "Payload")
+    new ApiImplicitParam(name = "namespace", required = false, dataType = "string", paramType = "query", value = "Namespace"),
+    new ApiImplicitParam(name = "name", required = false, dataType = "string", paramType = "query", value = "Name"),
+    new ApiImplicitParam(name = "id", required = false, dataType = "string", paramType = "query", value = "Id"),
+    new ApiImplicitParam(name = "synopsis", required = false, dataType = "string", paramType = "query", value = "Synopsis"),
+    new ApiImplicitParam(name = "documentation", required = false, dataType = "string", paramType = "query", value = "Documentation"),
+    new ApiImplicitParam(name = "owner", required = false, dataType = "string", paramType = "query", value = "Owner"),
+    new ApiImplicitParam(name = "payload", required = false, dataType = "string", paramType = "query", value = "Payload")
   ))
   @ApiResponses(Array(
     new ApiResponse(code = 200, message = "Successful Request"),


### PR DESCRIPTION
Spray-swagger moved from core swagger 1.2 - 1.3
Our params are not path params, but rather query params. They are also not required.