### PR TITLE
Fix search and unit tests

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
@@ -74,12 +74,12 @@ case class AgoraSearch(@(ApiModelProperty@field)(required = false, value = "The 
                        name: Option[String] = None,
                        @(ApiModelProperty@field)(required = false, value = "The method id")
                        var id: Option[Int] = None,
-                       @(ApiModelProperty@field)(required = false, value = "User who owns this method in the methods repo")
-                       owner: Option[String] = None,
                        @(ApiModelProperty@field)(required = false, value = "A short description of the method")
                        synopsis: Option[String] = None,
                        @(ApiModelProperty@field)(required = false, value = "Method documentation")
                        documentation: Option[String] = None,
+                       @(ApiModelProperty@field)(required = false, value = "User who owns this method in the methods repo")
+                       owner: Option[String] = None,
                        @(ApiModelProperty@field)(required = false, value = "The method payload")
                        payload: Option[String] = None
                       )

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -13,13 +13,15 @@ trait AgoraTestData {
   val namespace2 = "hellbender"
   val name1 = "testMethod1"
   val name2 = "testMethod2"
-  val synopsis = "This is a test method"
-  val documentation = "This is the documentation"
+  val synopsis1 = "This is a test method"
+  val synopsis2 = "This is another test method"
+  val documentation1 = "This is the documentation"
+  val documentation2 = "This is documentation for another method"
   // NB: save io by storing output.
   val bigDocumentation: String = getBigDocumentation
   val owner1 = "bob"
   val owner2 = "dave"
-  val payload = """task wc {
+  val payload1 = """task wc {
                   |  command {
                   |    echo "${str}" | wc -c
                   |  }
@@ -34,19 +36,58 @@ trait AgoraTestData {
                   |    call wc{input: str=s}
                   |  }
                   |}""".stripMargin
+  val payload2 = "task test {}"
 
-  val testEntity1 = AgoraEntity(namespace = Option(namespace1), name = Option(name1), owner = Option(owner1))
-  val testEntity2 = AgoraEntity(namespace = Option(namespace1), name = Option(name2), owner = Option(owner1))
-  val testEntity3 = AgoraEntity(namespace = Option(namespace2), name = Option(name1), owner = Option(owner1))
-  val testEntity4 = AgoraEntity(namespace = Option(namespace1), name = Option(name1), owner = Option(owner2))
-
+  val testEntity1 = AgoraEntity(namespace = Option(namespace1),
+                                name = Option(name1),
+                                synopsis = Option(synopsis1),
+                                documentation = Option(documentation1),
+                                owner = Option(owner1),
+                                payload = Option(payload1))
+  val testEntity2 = AgoraEntity(namespace = Option(namespace2),
+                                name = Option(name1),
+                                synopsis = Option(synopsis1),
+                                documentation = Option(documentation1),
+                                owner = Option(owner1),
+                                payload = Option(payload1))
+  val testEntity3 = AgoraEntity(namespace = Option(namespace1),
+                                name = Option(name2),
+                                synopsis = Option(synopsis1),
+                                documentation = Option(documentation1),
+                                owner = Option(owner1),
+                                payload = Option(payload1))
+  val testEntity4 = AgoraEntity(namespace = Option(namespace1),
+                                name = Option(name2),
+                                synopsis = Option(synopsis2),
+                                documentation = Option(documentation1),
+                                owner = Option(owner1),
+                                payload = Option(payload1))
+  val testEntity5 = AgoraEntity(namespace = Option(namespace1),
+                                name = Option(name2),
+                                synopsis = Option(synopsis1),
+                                documentation = Option(documentation2),
+                                owner = Option(owner1),
+                                payload = Option(payload1))
+  val testEntity6 = AgoraEntity(namespace = Option(namespace1),
+                                name = Option(name2),
+                                synopsis = Option(synopsis1),
+                                documentation = Option(documentation1),
+                                owner = Option(owner2),
+                                payload = Option(payload1))
+  val testEntity7 = AgoraEntity(namespace = Option(namespace1),
+                                name = Option(name2),
+                                synopsis = Option(synopsis1),
+                                documentation = Option(documentation1),
+                                owner = Option(owner1),
+                                payload = Option(payload2))
+  
   val testAddRequest = new AgoraAddRequest(
     namespace = namespace1,
     name = name1,
-    synopsis = synopsis,
-    documentation = documentation,
+    synopsis = synopsis1,
+    documentation = documentation1,
     owner = owner1,
-    payload = payload
+    payload = payload1
   )
 
   val badPayload = "task test {"
@@ -54,8 +95,8 @@ trait AgoraTestData {
   val testBadAddRequest = new AgoraAddRequest(
     namespace = namespace1,
     name = name1,
-    synopsis = synopsis,
-    documentation = documentation,
+    synopsis = synopsis1,
+    documentation = documentation1,
     owner = owner1,
     payload = badPayload
   )
@@ -63,9 +104,9 @@ trait AgoraTestData {
   val testAddRequestBigDoc = new AgoraAddRequest(
     namespace = namespace1,
     name = name1,
-    synopsis = synopsis,
+    synopsis = synopsis1,
     documentation = bigDocumentation,
     owner = owner1,
-    payload = payload
+    payload = payload1
   )
 }


### PR DESCRIPTION
Searches on owner, documentation, synopsis, and payload were failing. I changed the order of fields in AgoraSearch to match those in AgoraEntity and it is now working.

I also fixed the unit tests in ApiServiceSpec. They were erroneously passing because we had statements using === but not wrapped in assert(). So even if the === statements return false, the tests would pass.

Lastly, I added additional unit tests to verify search on owner, documentation, synopsis, and payload.