### PR TITLE
Removed salat for bson -> json and back. Just use JSON mongo util.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ libraryDependencies ++= Seq(
   "org.webjars" % "swagger-ui" % "2.0.24",
   "com.gettyimages" %% "spray-swagger" % "0.5.0",
   "org.mongodb" %% "casbah" % "2.8.1",
-  "com.novus" %% "salat" % "1.9.9",
   //---------- Test libraries -------------------//
   "io.spray" %% "spray-testkit" % sprayV % Test,
   "org.scalatest" %% "scalatest" % "2.2.4" % Test,

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/AgoraMongoDao.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/AgoraMongoDao.scala
@@ -1,18 +1,18 @@
 
 package org.broadinstitute.dsde.agora.server.dataaccess.mongo
 
-import com.mongodb.casbah.Imports._
-
-import com.mongodb.casbah.commons.MongoDBObject
 import com.mongodb.DBObject
+import com.mongodb.casbah.Imports._
 import com.mongodb.casbah.MongoCollection
+import com.mongodb.casbah.commons.MongoDBObject
 import com.mongodb.casbah.query.Imports
-import com.novus.salat._
-import com.novus.salat.global._
+import com.mongodb.util.JSON
 import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
 import org.broadinstitute.dsde.agora.server.dataaccess.mongo.AgoraMongoClient._
 import org.broadinstitute.dsde.agora.server.dataaccess.mongo.AgoraMongoDao._
+import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
+import spray.json._
 
 object AgoraMongoDao {
   val MongoDbIdField = "_id"
@@ -20,8 +20,9 @@ object AgoraMongoDao {
   val CounterSequenceField = "seq"
   val KeySeparator = ":"
 
-  def EntityToMongoDbObject(entity: AgoraEntity): DBObject = grater[AgoraEntity].asDBObject(entity)
-  def MongoDbObjectToEntity(mongoDBObject: DBObject): AgoraEntity = grater[AgoraEntity].asObject(mongoDBObject)
+  def EntityToMongoDbObject(entity: AgoraEntity): DBObject = JSON.parse(entity.toJson.toString()).asInstanceOf[DBObject]
+
+  def MongoDbObjectToEntity(mongoDBObject: DBObject): AgoraEntity = mongoDBObject.toString.parseJson.convertTo[AgoraEntity]
 }
 
 class AgoraMongoDao(collection: MongoCollection) extends AgoraDao {

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
@@ -1,0 +1,31 @@
+
+package org.broadinstitute.dsde.agora.server.model
+
+import org.joda.time.DateTime
+import org.joda.time.format.{DateTimeFormatter, ISODateTimeFormat}
+import spray.json._
+
+import scala.language.implicitConversions
+
+object AgoraApiJsonSupport extends DefaultJsonProtocol {
+
+  implicit def stringToDateTime(str: String): DateTime = parserISO.parseDateTime(str)
+
+  implicit object DateJsonFormat extends RootJsonFormat[DateTime] {
+    override def write(obj: DateTime) = {
+      JsString(parserISO.print(obj))
+    }
+
+    override def read(json: JsValue): DateTime = json match {
+      case JsString(s) => parserISO.parseDateTime(s)
+      case _ => throw new DeserializationException("only string supported")
+    }
+  }
+
+  private val parserISO: DateTimeFormatter = {
+    ISODateTimeFormat.dateTimeNoMillis()
+  }
+
+  implicit val AgoraEntityFormat = jsonFormat8(AgoraEntity)
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
@@ -1,52 +1,10 @@
 
 package org.broadinstitute.dsde.agora.server.model
 
-import java.util.Date
-
-import com.novus.salat._
-import com.novus.salat.global._
 import com.wordnik.swagger.annotations.{ApiModel, ApiModelProperty}
-import spray.http.HttpEntity
-import spray.http.MediaTypes._
-import spray.httpx.marshalling.Marshaller
-import spray.httpx.unmarshalling.Unmarshaller
+import org.joda.time.DateTime
 
 import scala.annotation.meta.field
-
-object AgoraEntity {
-  def fromAgoraAddRequest(agoraAddRequest: AgoraAddRequest, createDate: Option[Date]) = {
-    new AgoraEntity(namespace = Option(agoraAddRequest.namespace),
-      name = Option(agoraAddRequest.name),
-      synopsis = Option(agoraAddRequest.synopsis),
-      documentation = Option(agoraAddRequest.documentation),
-      owner = Option(agoraAddRequest.owner),
-      createDate = createDate,
-      payload = Option(agoraAddRequest.payload)
-    )
-  }
-  
-  def fromAgoraSearch(agoraSearch: AgoraSearch) = {
-    new AgoraEntity(namespace = agoraSearch.namespace,
-                    name = agoraSearch.name,
-                    id = agoraSearch.id,
-                    synopsis = agoraSearch.synopsis,
-                    documentation = agoraSearch.documentation,
-                    owner = agoraSearch.owner,
-                    payload = agoraSearch.payload)
-  }
-}
-
-object AgoraAddRequest {
-  implicit val AgoraAddRequestUnmarshaller =
-    Unmarshaller[AgoraAddRequest](`application/json`) {
-      case HttpEntity.NonEmpty(contentType, data) ⇒ grater[AgoraAddRequest].fromJSON(data.asString)
-    }
-
-  implicit val AgoraAddRequestMarshaller =
-    Marshaller.of[AgoraAddRequest](`application/json`) { (value, contentType, context) =>
-      context.marshalTo(HttpEntity(contentType, grater[AgoraAddRequest].toCompactJSON(value)))
-    }  
-}
 
 @ApiModel(value = "Agora Method")
 case class AgoraEntity(@(ApiModelProperty@field)(required = false, value = "The namespace to which the method belongs")
@@ -62,39 +20,7 @@ case class AgoraEntity(@(ApiModelProperty@field)(required = false, value = "The 
                        @(ApiModelProperty@field)(required = false, value = "User who owns this method in the methods repo")
                        owner: Option[String] = None,
                        @(ApiModelProperty@field)(required = false, value = "The date the method was inserted in the methods repo")
-                       createDate: Option[Date] = None,
+                       createDate: Option[DateTime] = None,
                        @(ApiModelProperty@field)(required = false, value = "The method payload")
                        payload: Option[String] = None
                         )
-
-@ApiModel(value = "Agora Search")
-case class AgoraSearch(@(ApiModelProperty@field)(required = false, value = "The namespace to which the method belongs")
-                       namespace: Option[String] = None,
-                       @(ApiModelProperty@field)(required = false, value = "The method name ")
-                       name: Option[String] = None,
-                       @(ApiModelProperty@field)(required = false, value = "The method id")
-                       var id: Option[Int] = None,
-                       @(ApiModelProperty@field)(required = false, value = "A short description of the method")
-                       synopsis: Option[String] = None,
-                       @(ApiModelProperty@field)(required = false, value = "Method documentation")
-                       documentation: Option[String] = None,
-                       @(ApiModelProperty@field)(required = false, value = "User who owns this method in the methods repo")
-                       owner: Option[String] = None,
-                       @(ApiModelProperty@field)(required = false, value = "The method payload")
-                       payload: Option[String] = None
-                      )
-
-@ApiModel(value = "Request to add method")
-case class AgoraAddRequest(@(ApiModelProperty@field)(required = true, value = "The namespace to which the method belongs")
-                           namespace: String,
-                           @(ApiModelProperty@field)(required = true, value = "The method name ")
-                           name: String,
-                           @(ApiModelProperty@field)(required = true, value = "A short description of the method")
-                           synopsis: String,
-                           @(ApiModelProperty@field)(required = true, value = "Method documentation")
-                           documentation: String,
-                           @(ApiModelProperty@field)(required = true, value = "User who owns this method in the methods repo")
-                           owner: String, // TODO: remove (use authenticated user)
-                           @(ApiModelProperty@field)(required = true, value = "The method payload")
-                           payload: String
-                            )

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/PerRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/PerRequest.scala
@@ -1,19 +1,18 @@
 package org.broadinstitute.dsde.agora.server.webservice
 
-import akka.actor._
 import akka.actor.SupervisorStrategy.Stop
-import PerRequest._
+import akka.actor.{OneForOneStrategy, _}
+import org.broadinstitute.dsde.agora.server.webservice.PerRequest._
+import spray.http.HttpHeader
 import spray.http.StatusCodes._
+import spray.httpx.marshalling.ToResponseMarshaller
 import spray.routing.RequestContext
-import akka.actor.OneForOneStrategy
-import spray.httpx.Json4sSupport
+
 import scala.concurrent.duration._
-import org.json4s.DefaultFormats
-import spray.http.StatusCode
 
 /**
  * This actor controls the lifecycle of a request. It is responsible for forwarding the initial message
- * to a target handling actor. This actor waits for the target actor signal completion (via a message),
+ * to a target handling actor. This actor waits for the target actor to signal completion (via a message),
  * timeout, or handle an exception. It is this actors responsibility to respond to the request and
  * shutdown itself and child actors.
  *
@@ -21,11 +20,8 @@ import spray.http.StatusCode
  * 1) with just a response object
  * 2) with a RequestComplete message which can specify http status code as well as the response
  */
-trait PerRequest extends Actor with Json4sSupport {
-
+trait PerRequest extends Actor {
   import context._
-
-  val json4sFormats = DefaultFormats
 
   def r: RequestContext
   def target: ActorRef
@@ -36,32 +32,64 @@ trait PerRequest extends Actor with Json4sSupport {
   target ! message
 
   def receive = {
-    case RequestComplete(statusCode, response) => complete(statusCode, response)
-    case ReceiveTimeout => complete(GatewayTimeout, "Request timeout")
-    case response: AnyRef => complete(OK, response)
+    case RequestComplete_(response, marshaller) => complete(response)(marshaller)
+    case RequestCompleteWithHeaders_(response, headers, marshaller) => complete(response, headers: _*)(marshaller)
+    case ReceiveTimeout => complete(GatewayTimeout)
+    case x =>
+      system.log.error("Unsupported response message sent to PerRequest actor: " + Option(x).getOrElse("null").toString)
+      complete(InternalServerError)
   }
 
-  def complete[T <: AnyRef](status: StatusCode, obj: T) = {
-    r.complete(status, obj)
+  /**
+   * Complete the request sending the given response and status code
+   * @param response to send to the caller
+   * @param marshaller to use for marshalling the response
+   * @return
+   */
+  private def complete[T](response: T, headers: HttpHeader*)(implicit marshaller: ToResponseMarshaller[T]) = {
+    r.withHttpResponseHeadersMapped(h => h ++ headers).complete(response)
     stop(self)
   }
 
   override val supervisorStrategy =
     OneForOneStrategy() {
       case e =>
-        complete(InternalServerError, e.getMessage)
+        system.log.error(e, "error processing request: " + r.request.uri)
+        r.complete(InternalServerError, e.getMessage)
         Stop
     }
 }
 
+
 object PerRequest {
+
+  sealed trait PerRequestMessage
   /**
-   * Message used to control the http status code sent to client
+   * Report complete, follows same pattern as spray.routing.RequestContext.complete; examples of how to call
+   * that method should apply here too. E.g. even though this method has only one parameter, it can be called
+   * with 2 where the first is a StatusCode: RequestComplete(StatusCode.Created, response)
    */
-  case class RequestComplete(statusCode: StatusCode, response: AnyRef)
+  case class RequestComplete[T](response: T)(implicit val marshaller: ToResponseMarshaller[T]) extends PerRequestMessage
+
+  /**
+   * Report complete with response headers. To response with a special status code the first parameter can be a
+   * tuple where the first element is StatusCode: RequestCompleteWithHeaders((StatusCode.Created, results), header).
+   * Note that this is here so that RequestComplete above can behave like spray.routing.RequestContext.complete.
+   */
+  case class RequestCompleteWithHeaders[T](response: T, headers: HttpHeader*)(implicit val marshaller: ToResponseMarshaller[T]) extends PerRequestMessage
+
+  /** allows for pattern matching with extraction of marshaller */
+  private object RequestComplete_ {
+    def unapply[T >: Any](requestComplete: RequestComplete[T]) = Some((requestComplete.response, requestComplete.marshaller))
+  }
+
+  /** allows for pattern matching with extraction of marshaller */
+  private object RequestCompleteWithHeaders_ {
+    def unapply[T >: Any](requestComplete: RequestCompleteWithHeaders[T]) = Some((requestComplete.response, requestComplete.headers, requestComplete.marshaller))
+  }
 
   case class WithProps(r: RequestContext, props: Props, message: AnyRef, timeout: Duration) extends PerRequest {
-    lazy val target = context.actorOf(props, "foo")
+    lazy val target = context.actorOf(props)
   }
 }
 
@@ -71,6 +99,6 @@ object PerRequest {
 trait PerRequestCreator {
   implicit def actorRefFactory: ActorRefFactory
 
-  def perRequest(r: RequestContext, props: Props, message: AnyRef, timeout: Duration = 1 minutes) =
+  def perRequest(r: RequestContext, props: Props, message: AnyRef, timeout: Duration = 1.minutes) =
     actorRefFactory.actorOf(Props(new WithProps(r, props, message, timeout)))
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsAddHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsAddHandler.scala
@@ -1,16 +1,15 @@
 package org.broadinstitute.dsde.agora.server.webservice.methods
 
-import java.util.Date
 import akka.actor.Actor
-import com.novus.salat._
-import com.novus.salat.global._
-import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
-import org.broadinstitute.dsde.agora.server.model.{AgoraAddRequest, AgoraEntity}
-import org.broadinstitute.dsde.agora.server.webservice.PerRequest.RequestComplete
-import org.broadinstitute.dsde.agora.server.webservice.util.ServiceMessages
 import cromwell.binding.WdlBinding
 import cromwell.parser.WdlParser.SyntaxError
+import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
+import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
+import org.broadinstitute.dsde.agora.server.webservice.PerRequest.RequestComplete
+import org.broadinstitute.dsde.agora.server.webservice.util.ServiceMessages
 import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
 import spray.routing.RequestContext
 
 /**
@@ -21,23 +20,22 @@ class MethodsAddHandler extends Actor {
   implicit val system = context.system
 
   def receive = {
-    case ServiceMessages.Add(requestContext: RequestContext, agoraAddRequest: AgoraAddRequest) =>
+    case ServiceMessages.Add(requestContext: RequestContext, agoraAddRequest: AgoraEntity) =>
       try {
         validatePayload(agoraAddRequest)
         add(requestContext, agoraAddRequest)
       } catch {
-        case e: SyntaxError => context.parent ! RequestComplete(BadRequest, "Syntax error in payload: " + e.getMessage())
+        case e: SyntaxError => context.parent ! RequestComplete(BadRequest, "Syntax error in payload: " + e.getMessage)
       }
       context.stop(self)
   }
 
-  private def validatePayload(agoraAddRequest: AgoraAddRequest): Unit = {
-    WdlBinding.getAst(agoraAddRequest.payload, agoraAddRequest.name)
+  private def validatePayload(agoraEntity: AgoraEntity): Unit = {
+    WdlBinding.getAst(agoraEntity.payload.get, agoraEntity.name.get)
   }
 
-  private def add(requestContext: RequestContext, agoraAddRequest: AgoraAddRequest): Unit = {
-    val agoraEntity = AgoraEntity.fromAgoraAddRequest(agoraAddRequest, createDate = Option(new Date())) 
+  private def add(requestContext: RequestContext, agoraEntity: AgoraEntity): Unit = {
     val method = AgoraDao.createAgoraDao.insert(agoraEntity)
-    context.parent ! grater[AgoraEntity].toJSON(method)
+    context.parent ! RequestComplete(method)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsQueryHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsQueryHandler.scala
@@ -2,14 +2,13 @@ package org.broadinstitute.dsde.agora.server.webservice.methods
 
 import akka.actor.Actor
 import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
-import org.broadinstitute.dsde.agora.server.model.{AgoraSearch, AgoraEntity}
-import org.broadinstitute.dsde.agora.server.webservice.util.ServiceMessages
+import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.PerRequest._
+import org.broadinstitute.dsde.agora.server.webservice.util.ServiceMessages
 import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
 import spray.routing.RequestContext
-import com.novus.salat._
-import com.novus.salat.global._
-
 
 /**
  * Actor responsible for querying the methods repository.
@@ -21,7 +20,7 @@ class MethodsQueryHandler extends Actor {
     case ServiceMessages.QueryByNamespaceNameId(requestContext: RequestContext, namespace: String, name: String, id: Int) =>
       query(requestContext, namespace, name, id)
       context.stop(self)
-    case ServiceMessages.Query(requestContext: RequestContext, agoraSearch: AgoraSearch) =>
+    case ServiceMessages.Query(requestContext: RequestContext, agoraSearch: AgoraEntity) =>
       query(requestContext, agoraSearch)
       context.stop(self)
   }
@@ -29,12 +28,12 @@ class MethodsQueryHandler extends Actor {
   def query(requestContext: RequestContext, namespace: String, name: String, id: Int): Unit = {
     AgoraDao.createAgoraDao.findSingle(namespace, name, id) match {
       case None => context.parent ! RequestComplete(NotFound, "Method: " + namespace + "/" + name + "/" + id + " not found")
-      case Some(method) => context.parent ! grater[AgoraEntity].toJSON(method)
+      case Some(method) => context.parent ! RequestComplete(method)
     }
   }
 
-  def query(requestContext: RequestContext, agoraSearch: AgoraSearch): Unit = {
-    val entities = AgoraDao.createAgoraDao.find(AgoraEntity.fromAgoraSearch(agoraSearch))
-    context.parent ! grater[AgoraEntity].toJSONArray(entities)
+  def query(requestContext: RequestContext, agoraSearch: AgoraEntity): Unit = {
+    val entities = AgoraDao.createAgoraDao.find(agoraSearch)
+    context.parent ! RequestComplete(entities)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsService.scala
@@ -1,15 +1,20 @@
 package org.broadinstitute.dsde.agora.server.webservice.methods
 
 import com.wordnik.swagger.annotations._
-import org.broadinstitute.dsde.agora.server.model.{AgoraSearch, AgoraAddRequest, AgoraEntity}
-import org.broadinstitute.dsde.agora.server.webservice.util.{ApiUtil, ServiceHandlerProps, ServiceMessages}
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.PerRequestCreator
+import org.broadinstitute.dsde.agora.server.webservice.util.{ApiUtil, ServiceHandlerProps, ServiceMessages}
+import org.joda.time.DateTime
 import spray.routing.HttpService
 
 @Api(value = "/methods", description = "Method Service", produces = "application/json", position = 1)
 trait MethodsService extends HttpService with PerRequestCreator {
-  this: ServiceHandlerProps => // Require a concrete ServiceHandlerProps creator to be mixed in
-  
+  this: ServiceHandlerProps =>
+  // Require a concrete ServiceHandlerProps creator to be mixed in
+
+  import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
+  import spray.httpx.SprayJsonSupport._
+
   val routes = queryByNamespaceNameIdRoute ~ queryRoute ~ postRoute
 
   @ApiOperation(value = "Get a method in the method repository matching namespace, name, and id",
@@ -41,7 +46,7 @@ trait MethodsService extends HttpService with PerRequestCreator {
     httpMethod = "GET",
     produces = "application/json",
     response = classOf[AgoraEntity],
-    responseContainer="Seq",
+    responseContainer = "Seq",
     notes = "API is rapidly changing.")
   @ApiImplicitParams(Array(
     new ApiImplicitParam(name = "namespace", required = false, dataType = "string", paramType = "query", value = "Namespace"),
@@ -59,10 +64,10 @@ trait MethodsService extends HttpService with PerRequestCreator {
   def queryRoute =
     path(ApiUtil.Methods.path) {
       get {
-        parameters('namespace?, 'name?, 'id.as[Int]?, 'synopsis?, 'documentation?, 'owner?, 'payload?).as(AgoraSearch) { agoraSearch =>
-        requestContext =>
-            perRequest(requestContext, methodsQueryHandlerProps, ServiceMessages.Query(requestContext, agoraSearch))
-          }
+        parameters("namespace".?, "name".?, "id".as[Int].?, "synopsis".?, "documentation".?, "owner".?, "createDate".as[DateTime].?, "payload".?).as(AgoraEntity) { agoraEntity =>
+          requestContext =>
+            perRequest(requestContext, methodsQueryHandlerProps, ServiceMessages.Query(requestContext, agoraEntity))
+        }
       }
     }
 
@@ -73,7 +78,7 @@ trait MethodsService extends HttpService with PerRequestCreator {
     response = classOf[AgoraEntity],
     notes = "API is rapidly changing.")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "body", required = true, dataType = "org.broadinstitute.dsde.agora.server.model.AgoraAddRequest", paramType = "body", value = "Agora Add Request")  ))
+    new ApiImplicitParam(name = "body", required = true, dataType = "org.broadinstitute.dsde.agora.server.model.AgoraEntity", paramType = "body", value = "Agora Entity")))
   @ApiResponses(Array(
     new ApiResponse(code = 200, message = "Successful Request"),
     new ApiResponse(code = 400, message = "Malformed Input"),
@@ -82,9 +87,9 @@ trait MethodsService extends HttpService with PerRequestCreator {
   def postRoute =
     path(ApiUtil.Methods.path) {
       post {
-        entity(as[AgoraAddRequest]) { agoraAddRequest =>
+        entity(as[AgoraEntity]) { agoraEntity =>
           requestContext =>
-            perRequest(requestContext, methodsAddHandlerProps, ServiceMessages.Add(requestContext, agoraAddRequest))
+            perRequest(requestContext, methodsAddHandlerProps, ServiceMessages.Add(requestContext, agoraEntity))
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/ServiceMessages.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/ServiceMessages.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.agora.server.webservice.util
 
-import org.broadinstitute.dsde.agora.server.model.{AgoraSearch, AgoraEntity, AgoraAddRequest}
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import spray.routing.RequestContext
 
 /**
@@ -9,7 +9,7 @@ import spray.routing.RequestContext
 object ServiceMessages {
   case class QueryByNamespaceNameId(requestContext: RequestContext, namespace: String, name: String, id: Int)
 
-  case class Query(requestContext: RequestContext, agoraSearch: AgoraSearch)
+  case class Query(requestContext: RequestContext, agoraSearch: AgoraEntity)
 
-  case class Add(requestContext: RequestContext, agoraAddRequest: AgoraAddRequest)
+  case class Add(requestContext: RequestContext, agoraAddRequest: AgoraEntity)
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.agora.server
 
-import org.broadinstitute.dsde.agora.server.model.{AgoraAddRequest, AgoraEntity}
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 
 trait AgoraTestData {
   def getBigDocumentation: String = {
@@ -8,80 +8,87 @@ trait AgoraTestData {
     val markdown = io.Source.fromFile("src/test/resources/TESTMARKDOWN.md").getLines() mkString "\n"
     markdown * 7  // NB: File is 1.6 Kb, so 7* that is >10kb, our minimal required storage amount.
   }
-  
-  val namespace1 = "broad"
-  val namespace2 = "hellbender"
-  val name1 = "testMethod1"
-  val name2 = "testMethod2"
-  val synopsis1 = "This is a test method"
-  val synopsis2 = "This is another test method"
-  val documentation1 = "This is the documentation"
-  val documentation2 = "This is documentation for another method"
-  // NB: save io by storing output.
-  val bigDocumentation: String = getBigDocumentation
-  val owner1 = "bob"
-  val owner2 = "dave"
-  val payload1 = """task wc {
-                  |  command {
-                  |    echo "${str}" | wc -c
-                  |  }
-                  |  output {
-                  |    int count = read_int("stdout") - 1
-                  |  }
-                  |}
-                  |
-                  |workflow wf {
-                  |  array[string] str_array
-                  |  scatter(s in str_array) {
-                  |    call wc{input: str=s}
-                  |  }
-                  |}""".stripMargin
-  val payload2 = "task test {}"
 
-  val testEntity1 = AgoraEntity(namespace = Option(namespace1),
-                                name = Option(name1),
-                                synopsis = Option(synopsis1),
-                                documentation = Option(documentation1),
-                                owner = Option(owner1),
-                                payload = Option(payload1))
-  val testEntity2 = AgoraEntity(namespace = Option(namespace2),
-                                name = Option(name1),
-                                synopsis = Option(synopsis1),
-                                documentation = Option(documentation1),
-                                owner = Option(owner1),
-                                payload = Option(payload1))
-  val testEntity3 = AgoraEntity(namespace = Option(namespace1),
-                                name = Option(name2),
-                                synopsis = Option(synopsis1),
-                                documentation = Option(documentation1),
-                                owner = Option(owner1),
-                                payload = Option(payload1))
-  val testEntity4 = AgoraEntity(namespace = Option(namespace1),
-                                name = Option(name2),
-                                synopsis = Option(synopsis2),
-                                documentation = Option(documentation1),
-                                owner = Option(owner1),
-                                payload = Option(payload1))
-  val testEntity5 = AgoraEntity(namespace = Option(namespace1),
-                                name = Option(name2),
-                                synopsis = Option(synopsis1),
-                                documentation = Option(documentation2),
-                                owner = Option(owner1),
-                                payload = Option(payload1))
-  val testEntity6 = AgoraEntity(namespace = Option(namespace1),
-                                name = Option(name2),
-                                synopsis = Option(synopsis1),
-                                documentation = Option(documentation1),
-                                owner = Option(owner2),
-                                payload = Option(payload1))
-  val testEntity7 = AgoraEntity(namespace = Option(namespace1),
-                                name = Option(name2),
-                                synopsis = Option(synopsis1),
-                                documentation = Option(documentation1),
-                                owner = Option(owner1),
-                                payload = Option(payload2))
-  
-  val testAddRequest = new AgoraAddRequest(
+  val namespace1 = Option("broad")
+  val namespace2 = Option("hellbender")
+  val name1 = Option("testMethod1")
+  val name2 = Option("testMethod2")
+  val synopsis1 = Option("This is a test method")
+  val synopsis2 = Option("This is another test method")
+  val documentation1 = Option("This is the documentation")
+  val documentation2 = Option("This is documentation for another method")
+  // NB: save io by storing output.
+  val bigDocumentation: Option[String] = Option(getBigDocumentation)
+  val owner1 = Option("bob")
+  val owner2 = Option("dave")
+  val payload1 = Option("""task wc {
+                   |  command {
+                   |    echo "${str}" | wc -c
+                   |  }
+                   |  output {
+                   |    int count = read_int("stdout") - 1
+                   |  }
+                   |}
+                   |
+                   |workflow wf {
+                   |  array[string] str_array
+                   |  scatter(s in str_array) {
+                   |    call wc{input: str=s}
+                   |  }
+                   |}""".stripMargin)
+  val payload2 = Option("task test {}")
+  val badPayload = Option("task test {")
+
+  val testEntity1 = AgoraEntity(namespace = namespace1,
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = owner1,
+    payload = payload1)
+
+  val testEntity2 = AgoraEntity(namespace = namespace2,
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = owner1,
+    payload = payload1)
+
+  val testEntity3 = AgoraEntity(namespace = namespace1,
+    name = name2,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = owner1,
+    payload = payload1)
+
+  val testEntity4 = AgoraEntity(namespace = namespace1,
+    name = name2,
+    synopsis = synopsis2,
+    documentation = documentation1,
+    owner = owner1,
+    payload = payload1)
+
+  val testEntity5 = AgoraEntity(namespace = namespace1,
+    name = name2,
+    synopsis = synopsis1,
+    documentation = documentation2,
+    owner = owner1,
+    payload = payload1)
+
+  val testEntity6 = AgoraEntity(namespace = namespace1,
+    name = name2,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = owner2,
+    payload = payload1)
+
+  val testEntity7 = AgoraEntity(namespace = namespace1,
+    name = name2,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = owner1,
+    payload = payload2)
+
+  val testAgoraEntity = new AgoraEntity(
     namespace = namespace1,
     name = name1,
     synopsis = synopsis1,
@@ -90,9 +97,7 @@ trait AgoraTestData {
     payload = payload1
   )
 
-  val badPayload = "task test {"
-
-  val testBadAddRequest = new AgoraAddRequest(
+  val testBadAgoraEntity = new AgoraEntity(
     namespace = namespace1,
     name = name1,
     synopsis = synopsis1,
@@ -101,7 +106,7 @@ trait AgoraTestData {
     payload = badPayload
   )
 
-  val testAddRequestBigDoc = new AgoraAddRequest(
+  val testAgoraEntityBigDoc = new AgoraEntity(
     namespace = namespace1,
     name = name1,
     synopsis = synopsis1,

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/MethodsDbTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/MethodsDbTest.scala
@@ -17,7 +17,7 @@ class MethodsDbTest extends FlatSpec with AgoraDbTest with AgoraTestData {
 
   "Agora" should "be able to query by namespace, name and version and get back a single entity" in {
     //NB: agoraTestMethod has already been stored.
-    val queryEntity = new AgoraEntity(namespace = Option(namespace1), name = Option(name1), id = testEntity1.id)
+    val queryEntity = new AgoraEntity(namespace = namespace1, name = name1, id = testEntity1.id)
 
     val entity = agoraDao.findSingle(queryEntity).get
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -1,19 +1,20 @@
 package org.broadinstitute.dsde.agora.server.webservice
 
+import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.methods.MethodsService
 import org.broadinstitute.dsde.agora.server.webservice.util.{ApiUtil, ServiceHandlerProps}
 import org.broadinstitute.dsde.agora.server.{AgoraDbTest, AgoraTestData}
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 import spray.http.StatusCodes._
-import spray.httpx.marshalling._
+import spray.httpx.SprayJsonSupport._
+import spray.httpx.unmarshalling._
 import spray.routing.Directives
 import spray.testkit.ScalatestRouteTest
-import com.novus.salat._
-import com.novus.salat.global._
 
 @DoNotDiscover
-class ApiServiceSpec extends FlatSpec with Matchers with Directives with ScalatestRouteTest with AgoraTestData with AgoraDbTest {
+class ApiServiceSpec extends FlatSpec with Matchers with Directives with ScalatestRouteTest
+with AgoraTestData with AgoraDbTest {
 
   trait ActorRefFactoryContext {
     def actorRefFactory = system
@@ -24,11 +25,9 @@ class ApiServiceSpec extends FlatSpec with Matchers with Directives with Scalate
   "Agora" should "return information about a method, including metadata " in {
     val insertedEntity = agoraDao.insert(testEntity1)
 
-    Get(ApiUtil.Methods.withLeadingSlash + "/" + namespace1 + "/" + name1 + "/"
+    Get(ApiUtil.Methods.withLeadingSlash + "/" + namespace1.get + "/" + name1.get + "/"
       + insertedEntity.id.get) ~> methodsService.queryByNamespaceNameIdRoute ~> check {
-      val rawResponse = responseAs[String]
-      val response = grater[AgoraEntity].fromJSONArray(rawResponse).head
-      assert(response === insertedEntity)
+      handleDeserializationErrors(entity.as[AgoraEntity], (entity: AgoraEntity) => assert(entity === insertedEntity))
     }
   }
 
@@ -39,57 +38,72 @@ class ApiServiceSpec extends FlatSpec with Matchers with Directives with Scalate
     agoraDao.insert(testEntity5)
     agoraDao.insert(testEntity6)
     agoraDao.insert(testEntity7)
-    Get(ApiUtil.Methods.withLeadingSlash + "?namespace=" + namespace1 + "&name=" + name2) ~> methodsService.queryRoute ~> check {
-      val rawResponse = responseAs[String]
-      val response = grater[AgoraEntity].fromJSONArray(rawResponse)
-      assert(response === Seq(testEntity3, testEntity4, testEntity5, testEntity6, testEntity7))
+    Get(ApiUtil.Methods.withLeadingSlash + "?namespace=" + namespace1.get + "&name=" + name2.get) ~>
+      methodsService.queryRoute ~> check {
+      handleDeserializationErrors(
+        entity.as[Seq[AgoraEntity]],
+        (entities: Seq[AgoraEntity]) =>
+          assert(entities === Seq(testEntity3, testEntity4, testEntity5, testEntity6, testEntity7))
+      )
     }
   }
 
   "Agora" should "return methods matching query by synopsis and documentation" in {
-    print(uriEncode(synopsis1))
-    Get(ApiUtil.Methods.withLeadingSlash + "?synopsis=" + uriEncode(synopsis1) + "&documentation=" + uriEncode(documentation1)) ~> methodsService.queryRoute ~> check {
-      val rawResponse = responseAs[String]
-      val response = grater[AgoraEntity].fromJSONArray(rawResponse)
-      assert(response === Seq(testEntity1, testEntity2, testEntity3, testEntity6, testEntity7))
+    Get(ApiUtil.Methods.withLeadingSlash + "?synopsis=" + uriEncode(synopsis1.get) + "&documentation=" +
+      uriEncode(documentation1.get)) ~> methodsService.queryRoute ~> check {
+      handleDeserializationErrors(
+        entity.as[Seq[AgoraEntity]],
+        (entities: Seq[AgoraEntity]) =>
+          assert(entities === Seq(testEntity1, testEntity2, testEntity3, testEntity6, testEntity7))
+      )
     }
   }
 
   "Agora" should "return methods matching query by owner and payload" in {
-    Get(ApiUtil.Methods.withLeadingSlash + "?owner=" + owner1 + "&payload=" + uriEncode(payload1)) ~> methodsService.queryRoute ~> check {
-      val rawResponse = responseAs[String]
-      val response = grater[AgoraEntity].fromJSONArray(rawResponse)
-      assert(response === Seq(testEntity1, testEntity2, testEntity3, testEntity4, testEntity5))
+    Get(ApiUtil.Methods.withLeadingSlash + "?owner=" + owner1.get + "&payload=" + uriEncode(payload1.get)) ~>
+      methodsService.queryRoute ~> check {
+      handleDeserializationErrors(
+        entity.as[Seq[AgoraEntity]],
+        (entities: Seq[AgoraEntity]) =>
+          assert(entities === Seq(testEntity1, testEntity2, testEntity3, testEntity4, testEntity5))
+      )
     }
   }
 
   "Agora" should "create and return a method" in {
-    Post(ApiUtil.Methods.withLeadingSlash, marshal(testAddRequest)) ~> methodsService.postRoute ~> check {
-      val rawResponse = responseAs[String]
-      val response = grater[AgoraEntity].fromJSON(rawResponse)
-      assert(response.namespace.get === namespace1)
-      assert(response.name.get === name1)
-      assert(response.synopsis.get === synopsis1)
-      assert(response.documentation.get === documentation1)
-      assert(response.owner.get === owner1)
-      assert(response.payload.get === payload1)
-      assert(response.id.get !== None)
-      assert(response.createDate.get != null)
+    Post(ApiUtil.Methods.withLeadingSlash, testAgoraEntity) ~> methodsService.postRoute ~> check {
+      handleDeserializationErrors(entity.as[AgoraEntity], (entity: AgoraEntity) => {
+        assert(entity.namespace === namespace1)
+        assert(entity.name === name1)
+        assert(entity.synopsis === synopsis1)
+        assert(entity.documentation === documentation1)
+        assert(entity.owner === owner1)
+        assert(entity.payload === payload1)
+        assert(entity.id !== None)
+        assert(entity.createDate != null)
+      }
+      )
     }
   }
 
   "Agora" should "return a 400 bad request when posting a malformed payload" in {
-    Post(ApiUtil.Methods.withLeadingSlash, marshal(testBadAddRequest)) ~> methodsService.postRoute ~> check {
+    Post(ApiUtil.Methods.withLeadingSlash, testBadAgoraEntity) ~> methodsService.postRoute ~> check {
       assert(status === BadRequest)
       assert(responseAs[String] != null)
     }
   }
 
   "Agora" should "store 10kb of github markdown as method documentation and return it without alteration" in {
-    Post(ApiUtil.Methods.withLeadingSlash, marshal(testAddRequestBigDoc)) ~> methodsService.postRoute ~> check {
-      val rawResponse = responseAs[String]
-      assert(grater[AgoraEntity].fromJSON(rawResponse).documentation.get === bigDocumentation)
+    Post(ApiUtil.Methods.withLeadingSlash, testAgoraEntityBigDoc) ~> methodsService.postRoute ~> check {
+      handleDeserializationErrors(
+        entity.as[AgoraEntity],
+        (entity: AgoraEntity) => assert(entity.documentation.get === bigDocumentation)
+      )
     }
+  }
+
+  def handleDeserializationErrors[T](deserialized: Deserialized[T], assertions: (T) => Unit) = {
+    if (deserialized.isRight) assertions else failTest(deserialized.left.get.toString)
   }
 
   def uriEncode(uri: String): String = {


### PR DESCRIPTION
Removed salat for bson -> json and back. Just use JSON mongo util. Updated per request from Rawls. String to DateTime implicit conversion to make the search work on a standard AgoraEntity. Added AgoraApiJsonSupport back since we
 are using spray json again.

We probably want to make sure everyone has their code merged back to master before we merge this guy.