### PR TITLE
Add URL pointing to details for each search listing

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+webservice.scheme = "http"
+webservice.host = "localhost"
 webservice.port = 8000
 webservice.interface = 0.0.0.0
 instance.name = "reference"

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
@@ -26,6 +26,6 @@ object AgoraApiJsonSupport extends DefaultJsonProtocol {
     ISODateTimeFormat.dateTimeNoMillis()
   }
 
-  implicit val AgoraEntityFormat = jsonFormat8(AgoraEntity)
+  implicit val AgoraEntityFormat = jsonFormat9(AgoraEntity)
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
@@ -22,5 +22,7 @@ case class AgoraEntity(@(ApiModelProperty@field)(required = false, value = "The 
                        @(ApiModelProperty@field)(required = false, value = "The date the method was inserted in the methods repo")
                        createDate: Option[DateTime] = None,
                        @(ApiModelProperty@field)(required = false, value = "The method payload")
-                       payload: Option[String] = None
+                       payload: Option[String] = None,
+                       @(ApiModelProperty@field)(required = false, value = "URI for method details")
+                       url: Option[String] = None
                         )

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsQueryHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsQueryHandler.scala
@@ -5,7 +5,7 @@ import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
 import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.PerRequest._
-import org.broadinstitute.dsde.agora.server.webservice.util.ServiceMessages
+import org.broadinstitute.dsde.agora.server.webservice.util.{ApiUtil, ServiceMessages}
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.routing.RequestContext
@@ -33,7 +33,8 @@ class MethodsQueryHandler extends Actor {
   }
 
   def query(requestContext: RequestContext, agoraSearch: AgoraEntity): Unit = {
-    val entities = AgoraDao.createAgoraDao.find(agoraSearch)
+    val entities = AgoraDao.createAgoraDao.find(agoraSearch).map(entity => entity.copy(url = Option(ApiUtil.agoraUrl(entity))))
     context.parent ! RequestComplete(entities)
   }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsService.scala
@@ -64,7 +64,7 @@ trait MethodsService extends HttpService with PerRequestCreator {
   def queryRoute =
     path(ApiUtil.Methods.path) {
       get {
-        parameters("namespace".?, "name".?, "snapshotId".as[Int].?, "synopsis".?, "documentation".?, "owner".?, "createDate".as[DateTime].?, "payload".?).as(AgoraEntity) { agoraEntity =>
+        parameters("namespace".?, "name".?, "snapshotId".as[Int].?, "synopsis".?, "documentation".?, "owner".?, "createDate".as[DateTime].?, "payload".?, "url".?).as(AgoraEntity) { agoraEntity =>
           requestContext =>
             perRequest(requestContext, methodsQueryHandlerProps, ServiceMessages.Query(requestContext, agoraEntity))
         }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/ApiUtil.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/ApiUtil.scala
@@ -1,12 +1,26 @@
 package org.broadinstitute.dsde.agora.server.webservice.util
 
+import org.broadinstitute.dsde.agora.server.AgoraConfig
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
+import net.ceedubs.ficus.Ficus._
+
 object ApiUtil {
   val Methods: ServiceRoute = new ServiceRoute("methods")
+
+  val scheme = AgoraConfig.appConfig.as[Option[String]]("webservice.scheme").getOrElse("http")
+  val host = AgoraConfig.appConfig.as[Option[String]]("webservice.host").getOrElse("localhost")
+  val port = AgoraConfig.appConfig.as[Option[Int]]("webservice.port").getOrElse(8000)
+  val baseUrl = scheme + "://" + host + ":" + port
+  val methodsUrl = baseUrl + Methods.withLeadingSlash + "/"
 
   class ServiceRoute(val path: String) {
     def withLeadingSlash: String = {
       "/" + path
     }
+  }
+
+  def agoraUrl(entity: AgoraEntity): String = {
+    methodsUrl + entity.namespace.get + "/" + entity.name.get + "/" + entity.snapshotId.get
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -104,7 +104,8 @@ with AgoraTestData with AgoraDbTest {
         name = entity.name,
         snapshotId = entity.snapshotId,
         synopsis = entity.synopsis,
-        owner = entity.owner
+        owner = entity.owner,
+        url = Option(ApiUtil.agoraUrl(entity))
       )
     )
   }


### PR DESCRIPTION
Each item in the search results json now includes a URL pointing to the detailed view of that method. In order to construct these URLs, Agora must know its own base URL, so I've added scheme and host to the agora config file (port was already there).