### PR TITLE
Add URL for detailed method record to each search listing

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,3 +1,5 @@
+webservice.scheme = "http"
+webservice.host = "localhost"
 webservice.port = 8000
 webservice.interface = 0.0.0.0
 instance.name = "reference"

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/Agora.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/Agora.scala
@@ -4,7 +4,7 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 
 object Agora extends LazyLogging {
   val server: ServerInitializer = {
-    new ServerInitializer(AgoraConfig.appConfig)
+    new ServerInitializer()
   }
 
   sys addShutdownHook stop()
@@ -15,7 +15,7 @@ object Agora extends LazyLogging {
 
   def start(): Unit = {
     server.startAllServices()
-    logger.info("Agora instance " + server.serverInstanceName + " initialized.")
+    logger.info("Agora instance " + AgoraConfig.serverInstanceName + " initialized.")
   }
 
   def stop() {

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/AgoraConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/AgoraConfig.scala
@@ -2,14 +2,27 @@
 package org.broadinstitute.dsde.agora.server
 
 import java.io.File
-
+import net.ceedubs.ficus.Ficus._
 import com.typesafe.config.{Config, ConfigFactory}
 
 object AgoraConfig {
   private val config: Config = ConfigFactory.load() 
   private val agoraConfig: Config = ConfigFactory.parseFile(new File("/etc/agora.conf"))
 
-  def appConfig = agoraConfig.withFallback(config)
+  private val appConfig = agoraConfig.withFallback(config)
+  lazy val serverInstanceName = appConfig.as[String]("instance.name")
+  private lazy val scheme = appConfig.as[Option[String]]("webservice.scheme").getOrElse("http")
+  private lazy val host = appConfig.as[Option[String]]("webservice.host").getOrElse("localhost")
+  lazy val port = appConfig.as[Option[Int]]("webservice.port").getOrElse(8000)
+  private lazy val baseUrl = scheme + "://" + host + ":" + port + "/"
+  lazy val methodsRoute = appConfig.as[Option[String]]("methods.route").getOrElse("methods")
+  lazy val methodsUrl = baseUrl + methodsRoute + "/"
+  lazy val webserviceInterface = appConfig.as[Option[String]]("webservice.interface").getOrElse("0.0.0.0")
+
+  lazy val mongoDbHost = appConfig.as[Option[String]]("mongodb.host").getOrElse("localhost")
+  lazy val mongoDbPort = appConfig.as[Option[Int]]("mongodb.port").getOrElse(27017)
+  lazy val mongoDbUser = appConfig.as[Option[String]]("mongodb.user")
+  lazy val mongoDbPassword = appConfig.as[Option[String]]("mongodb.password")
 
   //Config Settings
   object SwaggerConfig {

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/ServerInitializer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/ServerInitializer.scala
@@ -5,9 +5,7 @@ import akka.io.IO
 import akka.io.Tcp.CommandFailed
 import akka.pattern.ask
 import akka.util.Timeout
-import com.typesafe.config.Config
 import com.typesafe.scalalogging.slf4j.LazyLogging
-import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.agora.server.webservice.ApiServiceActor
 import spray.can.Http
 
@@ -15,17 +13,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
 
-class ServerInitializer(val config: Config) extends LazyLogging {
+class ServerInitializer extends LazyLogging {
   implicit val actorSystem = ActorSystem("agora")
-
-  lazy val serverInstanceName = config.as[String]("instance.name")
-  lazy val webservicePort = config.as[Option[Int]]("webservice.port").getOrElse(8000)
-  lazy val webserviceInterface = config.as[Option[String]]("webservice.interface").getOrElse("0.0.0.0")
-
-  lazy val mongoDbHost = config.as[Option[String]]("mongodb.host").getOrElse("localhost")
-  lazy val mongoDbPort = config.as[Option[Int]]("mongodb.port").getOrElse(27017)
-  lazy val mongoDbUser = config.as[Option[String]]("mongodb.user")
-  lazy val mongoDbPassword = config.as[Option[String]]("mongodb.password")
 
   def startAllServices() {
     startWebServiceActors()
@@ -38,9 +27,9 @@ class ServerInitializer(val config: Config) extends LazyLogging {
   private def startWebServiceActors() = {
     implicit val timeout = Timeout(5.seconds)
     val service = actorSystem.actorOf(ApiServiceActor.props, "agora-actor")
-    Await.result(IO(Http) ? Http.Bind(service, interface = webserviceInterface, port = webservicePort), timeout.duration) match {
+    Await.result(IO(Http) ? Http.Bind(service, interface = AgoraConfig.webserviceInterface, port = AgoraConfig.port), timeout.duration) match {
       case CommandFailed(b: Http.Bind) =>
-        logger.error(s"Unable to bind to port $webservicePort on interface $webserviceInterface")
+        logger.error(s"Unable to bind to port ${AgoraConfig.port} on interface ${AgoraConfig.webserviceInterface}")
         actorSystem.shutdown()
         stopAndExit()
       case _ =>

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
@@ -1,0 +1,36 @@
+package org.broadinstitute.dsde.agora.server.business
+
+import org.broadinstitute.dsde.agora.server.AgoraConfig
+import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
+
+/**
+ * Created by dshiga on 5/13/15.
+ */
+object AgoraBusiness {
+
+  def agoraUrl(entity: AgoraEntity): String = {
+    AgoraConfig.methodsUrl + entity.namespace.get + "/" + entity.name.get + "/" + entity.snapshotId.get
+  }
+
+  def addUrl(entity: AgoraEntity): AgoraEntity = {
+    entity.copy(url = Option(agoraUrl(entity)))
+  }
+
+  def insert(agoraEntity: AgoraEntity): AgoraEntity = {
+    AgoraDao.createAgoraDao.insert(agoraEntity).copy(url = Option(agoraUrl(agoraEntity)))
+  }
+
+  def find(agoraSearch: AgoraEntity): Seq[AgoraEntity] = {
+    AgoraDao.createAgoraDao.find(agoraSearch).map(entity => entity.copy(url = Option(agoraUrl(entity))))
+  }
+
+  def findSingle(namespace: String, name: String, snapshotId: Int): Option[AgoraEntity] = {
+    AgoraDao.createAgoraDao.findSingle(namespace, name, snapshotId).map(entity => entity.copy(url = Option(agoraUrl(entity))))
+  }
+
+  def findSingle(entity: AgoraEntity): Option[AgoraEntity] = {
+    AgoraDao.createAgoraDao.findSingle(entity).map(entity => entity.copy(url = Option(agoraUrl(entity))))
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/AgoraMongoClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/AgoraMongoClient.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.agora.server.dataaccess.mongo
 
 import com.mongodb.casbah.{MongoClient, MongoCollection, MongoDB}
 import com.mongodb.{MongoCredential, ServerAddress}
-import org.broadinstitute.dsde.agora.server.Agora
+import org.broadinstitute.dsde.agora.server.{AgoraConfig, Agora}
 
 object AgoraMongoClient {
 
@@ -19,10 +19,10 @@ object AgoraMongoClient {
   }
 
   def getMongoClient: MongoClient = {
-    val server = new ServerAddress(Agora.server.mongoDbHost, Agora.server.mongoDbPort)
+    val server = new ServerAddress(AgoraConfig.mongoDbHost, AgoraConfig.mongoDbPort)
 
-    val user: Option[String] = Agora.server.mongoDbUser
-    val password: Option[String] = Agora.server.mongoDbPassword
+    val user: Option[String] = AgoraConfig.mongoDbUser
+    val password: Option[String] = AgoraConfig.mongoDbPassword
 
     (user, password) match {
       case (Some(userName), Some(userPassword)) =>

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
@@ -26,6 +26,6 @@ object AgoraApiJsonSupport extends DefaultJsonProtocol {
     ISODateTimeFormat.dateTimeNoMillis()
   }
 
-  implicit val AgoraEntityFormat = jsonFormat8(AgoraEntity)
+  implicit val AgoraEntityFormat = jsonFormat9(AgoraEntity)
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
@@ -22,5 +22,7 @@ case class AgoraEntity(@(ApiModelProperty@field)(required = false, value = "The 
                        @(ApiModelProperty@field)(required = false, value = "The date the method was inserted in the methods repo")
                        createDate: Option[DateTime] = None,
                        @(ApiModelProperty@field)(required = false, value = "The method payload")
-                       payload: Option[String] = None
+                       payload: Option[String] = None,
+                       @(ApiModelProperty@field)(required = false, value = "URI for method details")
+                       url: Option[String] = None
                         )

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsAddHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsAddHandler.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.agora.server.webservice.methods
 import akka.actor.Actor
 import cromwell.binding.WdlBinding
 import cromwell.parser.WdlParser.SyntaxError
-import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
+import org.broadinstitute.dsde.agora.server.business.AgoraBusiness
 import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.PerRequest.RequestComplete
@@ -35,7 +35,7 @@ class MethodsAddHandler extends Actor {
   }
 
   private def add(requestContext: RequestContext, agoraEntity: AgoraEntity): Unit = {
-    val method = AgoraDao.createAgoraDao.insert(agoraEntity)
+    val method = AgoraBusiness.insert(agoraEntity)
     context.parent ! RequestComplete(spray.http.StatusCodes.Created.intValue, method)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsQueryHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsQueryHandler.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.agora.server.webservice.methods
 
 import akka.actor.Actor
-import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
+import org.broadinstitute.dsde.agora.server.business.AgoraBusiness
 import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.PerRequest._
@@ -26,14 +26,15 @@ class MethodsQueryHandler extends Actor {
   }
 
   def query(requestContext: RequestContext, namespace: String, name: String, snapshotId: Int): Unit = {
-    AgoraDao.createAgoraDao.findSingle(namespace, name, snapshotId) match {
+    AgoraBusiness.findSingle(namespace, name, snapshotId) match {
       case None => context.parent ! RequestComplete(NotFound, "Method: " + namespace + "/" + name + "/" + snapshotId + " not found")
       case Some(method) => context.parent ! RequestComplete(method)
     }
   }
 
   def query(requestContext: RequestContext, agoraSearch: AgoraEntity): Unit = {
-    val entities = AgoraDao.createAgoraDao.find(agoraSearch)
+    val entities = AgoraBusiness.find(agoraSearch)
     context.parent ! RequestComplete(entities)
   }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsService.scala
@@ -64,7 +64,7 @@ trait MethodsService extends HttpService with PerRequestCreator {
   def queryRoute =
     path(ApiUtil.Methods.path) {
       get {
-        parameters("namespace".?, "name".?, "snapshotId".as[Int].?, "synopsis".?, "documentation".?, "owner".?, "createDate".as[DateTime].?, "payload".?).as(AgoraEntity) { agoraEntity =>
+        parameters("namespace".?, "name".?, "snapshotId".as[Int].?, "synopsis".?, "documentation".?, "owner".?, "createDate".as[DateTime].?, "payload".?, "url".?).as(AgoraEntity) { agoraEntity =>
           requestContext =>
             perRequest(requestContext, methodsQueryHandlerProps, ServiceMessages.Query(requestContext, agoraEntity))
         }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/ApiUtil.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/ApiUtil.scala
@@ -1,12 +1,13 @@
 package org.broadinstitute.dsde.agora.server.webservice.util
 
+import org.broadinstitute.dsde.agora.server.AgoraConfig
+
 object ApiUtil {
-  val Methods: ServiceRoute = new ServiceRoute("methods")
+  val Methods = new ServiceRoute(AgoraConfig.methodsRoute)
 
   class ServiceRoute(val path: String) {
     def withLeadingSlash: String = {
       "/" + path
     }
   }
-
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
@@ -15,7 +15,7 @@ class AgoraTestSuite extends Suites(new ApiServiceSpec, new MethodsDbTest) with 
 
   override def beforeAll() {
     println("Starting embedded mongo db instance.")
-    mongoProps = mongoStart(port = Agora.server.mongoDbPort)
+    mongoProps = mongoStart(port = AgoraConfig.mongoDbPort)
     println("Starting Agora web services.")
     Agora.start()
   }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.agora.server.webservice
 
+import org.broadinstitute.dsde.agora.server.business.AgoraBusiness
 import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.methods.MethodsService
@@ -14,7 +15,7 @@ import spray.testkit.ScalatestRouteTest
 
 @DoNotDiscover
 class ApiServiceSpec extends FlatSpec with Matchers with Directives with ScalatestRouteTest
-with AgoraTestData with AgoraDbTest {
+with AgoraTestData {
 
   trait ActorRefFactoryContext {
     def actorRefFactory = system
@@ -23,7 +24,7 @@ with AgoraTestData with AgoraDbTest {
   val methodsService = new MethodsService with ActorRefFactoryContext with ServiceHandlerProps
 
   "Agora" should "return information about a method, including metadata " in {
-    val insertedEntity = agoraDao.insert(testEntity1)
+    val insertedEntity = AgoraBusiness.insert(testEntity1)
 
     Get(ApiUtil.Methods.withLeadingSlash + "/" + namespace1.get + "/" + name1.get + "/"
       + insertedEntity.snapshotId.get) ~> methodsService.queryByNamespaceNameSnapshotIdRoute ~> check {
@@ -34,12 +35,12 @@ with AgoraTestData with AgoraDbTest {
   }
 
   "Agora" should "return methods matching query by namespace and name" in {
-    agoraDao.insert(testEntity2)
-    agoraDao.insert(testEntity3)
-    agoraDao.insert(testEntity4)
-    agoraDao.insert(testEntity5)
-    agoraDao.insert(testEntity6)
-    agoraDao.insert(testEntity7)
+    AgoraBusiness.insert(testEntity2)
+    AgoraBusiness.insert(testEntity3)
+    AgoraBusiness.insert(testEntity4)
+    AgoraBusiness.insert(testEntity5)
+    AgoraBusiness.insert(testEntity6)
+    AgoraBusiness.insert(testEntity7)
     Get(ApiUtil.Methods.withLeadingSlash + "?namespace=" + namespace1.get + "&name=" + name2.get) ~>
       methodsService.queryRoute ~> check {
       val entities = handleDeserializationErrors(entity.as[Seq[AgoraEntity]])
@@ -110,7 +111,8 @@ with AgoraTestData with AgoraDbTest {
         name = entity.name,
         snapshotId = entity.snapshotId,
         synopsis = entity.synopsis,
-        owner = entity.owner
+        owner = entity.owner,
+        url = Option(AgoraBusiness.agoraUrl(entity))
       )
     )
   }


### PR DESCRIPTION
I also made changes to how we're handling configuration, to avoid having duplicate lines like the following in multiple classes:
lazy val port = appConfig.as[Option[Int]]("webservice.port").getOrElse(8000)

I moved lines like this into AgoraConfig itself so they happen in one central place.

Most of the changes here are due to this configuration refactoring.