### PR TITLE
Fix url building when data is missing, fix createDate

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
@@ -7,7 +7,14 @@ import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 object AgoraBusiness {
 
   def agoraUrl(entity: AgoraEntity): String = {
-    AgoraConfig.methodsUrl + entity.namespace.get + "/" + entity.name.get + "/" + entity.snapshotId.get
+    hasNamespaceNameId(entity) match {
+      case true => AgoraConfig.methodsUrl + entity.namespace.get + "/" + entity.name.get + "/" + entity.snapshotId.get
+      case false => ""
+    }
+  }
+
+  def hasNamespaceNameId(entity: AgoraEntity): Boolean = {
+    entity.namespace.exists(_.trim.nonEmpty) && entity.name.exists(_.trim.nonEmpty) && entity.snapshotId.nonEmpty
   }
 
   def addUrl(entity: AgoraEntity): AgoraEntity = {

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsAddHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsAddHandler.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.PerRequest.RequestComplete
 import org.broadinstitute.dsde.agora.server.webservice.util.ServiceMessages
+import org.joda.time.DateTime
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.routing.RequestContext
@@ -35,7 +36,7 @@ class MethodsAddHandler extends Actor {
   }
 
   private def add(requestContext: RequestContext, agoraEntity: AgoraEntity): Unit = {
-    val method = AgoraBusiness.insert(agoraEntity)
+    val method = AgoraBusiness.insert(agoraEntity.copy(createDate = Option(new DateTime())))
     context.parent ! RequestComplete(spray.http.StatusCodes.Created.intValue, method)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.agora.server
 
 import com.github.simplyscala.{MongoEmbedDatabase, MongodProps}
+import org.broadinstitute.dsde.agora.server.business.AgoraBusinessTest
 import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
 import org.broadinstitute.dsde.agora.server.dataaccess.mongo.MethodsDbTest
 import org.broadinstitute.dsde.agora.server.webservice.ApiServiceSpec
@@ -10,7 +11,7 @@ trait AgoraDbTest {
   val agoraDao = AgoraDao.createAgoraDao
 }
 
-class AgoraTestSuite extends Suites(new ApiServiceSpec, new MethodsDbTest) with BeforeAndAfterAll with MongoEmbedDatabase {
+class AgoraTestSuite extends Suites(new ApiServiceSpec, new MethodsDbTest, new AgoraBusinessTest) with BeforeAndAfterAll with MongoEmbedDatabase {
   var mongoProps: MongodProps = null
 
   override def beforeAll() {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.agora.server.business
+
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
+import org.scalatest.{Matchers, FlatSpec, DoNotDiscover}
+
+/**
+ * Created by dshiga on 5/14/15.
+ */
+@DoNotDiscover
+class AgoraBusinessTest extends FlatSpec with Matchers {
+
+  "Agora" should "return an empty URL if entity namespace, name, or snapshotId are missing" in {
+    val noNamespace = AgoraEntity(name = Option("test"), snapshotId = Option(12))
+    val blankName = AgoraEntity(namespace = Option("broad"), name = Option("   "), snapshotId = Option(12))
+    val noSnapshotId = AgoraEntity(namespace = Option("broad"), name = Option("test"))
+    assert(AgoraBusiness.agoraUrl(noNamespace) === "")
+    assert(AgoraBusiness.agoraUrl(blankName) === "")
+    assert(AgoraBusiness.agoraUrl(noSnapshotId) === "")
+  }
+
+  "Agora" should "return a URL given an entity with a namespace, name, and id" in {
+    val entity = AgoraEntity(namespace = Option("broad"), name = Option("test"), snapshotId = Option(12))
+    assert(AgoraBusiness.agoraUrl(entity) === "http://localhost:8000/methods/broad/test/12")
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -98,6 +98,7 @@ with AgoraTestData with BeforeAndAfterAll {
         assert(entity.owner === agoraCIOwner)
         assert(entity.payload === payload1)
         assert(entity.snapshotId !== None)
+        assert(entity.createDate !== None)
       })
       assert(status === Created)
     }


### PR DESCRIPTION
Fix url building when namespace, name, or id is missing (return empty string). Populate createDate when inserting a new method.