### PR TITLE
Return 4xx errors in JSON format to fix swagger UI

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
@@ -28,4 +28,5 @@ object AgoraApiJsonSupport extends DefaultJsonProtocol {
 
   implicit val AgoraEntityFormat = jsonFormat9(AgoraEntity)
 
+  implicit val AgoraErrorFormat = jsonFormat1(AgoraError)
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraError.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraError.scala
@@ -1,0 +1,13 @@
+package org.broadinstitute.dsde.agora.server.model
+
+import com.wordnik.swagger.annotations.{ApiModelProperty, ApiModel}
+
+import scala.annotation.meta.field
+
+/**
+ * Created by dshiga on 5/15/15.
+ */
+@ApiModel(value = "Agora Method")
+case class AgoraError(@(ApiModelProperty@field)(required = true, value = "The error message")
+                       error: String
+                        )

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsAddHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsAddHandler.scala
@@ -5,7 +5,7 @@ import cromwell.binding.WdlBinding
 import cromwell.parser.WdlParser.SyntaxError
 import org.broadinstitute.dsde.agora.server.business.AgoraBusiness
 import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
-import org.broadinstitute.dsde.agora.server.model.AgoraEntity
+import org.broadinstitute.dsde.agora.server.model.{AgoraError, AgoraEntity}
 import org.broadinstitute.dsde.agora.server.webservice.PerRequest.RequestComplete
 import org.broadinstitute.dsde.agora.server.webservice.util.ServiceMessages
 import org.joda.time.DateTime
@@ -26,7 +26,7 @@ class MethodsAddHandler extends Actor {
         validatePayload(agoraAddRequest)
         add(requestContext, agoraAddRequest)
       } catch {
-        case e: SyntaxError => context.parent ! RequestComplete(BadRequest, "Syntax error in payload: " + e.getMessage)
+        case e: SyntaxError => context.parent ! RequestComplete(BadRequest, AgoraError("Syntax error in payload: " + e.getMessage))
       }
       context.stop(self)
   }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsQueryHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/methods/MethodsQueryHandler.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.agora.server.webservice.methods
 import akka.actor.Actor
 import org.broadinstitute.dsde.agora.server.business.AgoraBusiness
 import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
-import org.broadinstitute.dsde.agora.server.model.AgoraEntity
+import org.broadinstitute.dsde.agora.server.model.{AgoraError, AgoraEntity}
 import org.broadinstitute.dsde.agora.server.webservice.PerRequest._
 import org.broadinstitute.dsde.agora.server.webservice.util.ServiceMessages
 import spray.http.StatusCodes._
@@ -27,7 +27,7 @@ class MethodsQueryHandler extends Actor {
 
   def query(requestContext: RequestContext, namespace: String, name: String, snapshotId: Int): Unit = {
     AgoraBusiness.findSingle(namespace, name, snapshotId) match {
-      case None => context.parent ! RequestComplete(NotFound, "Method: " + namespace + "/" + name + "/" + snapshotId + " not found")
+      case None => context.parent ! RequestComplete(NotFound, AgoraError(s"Method: ${namespace}/${name}/${snapshotId} not found"))
       case Some(method) => context.parent ! RequestComplete(method)
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -12,6 +12,7 @@ import spray.httpx.SprayJsonSupport._
 import spray.httpx.unmarshalling._
 import spray.routing.Directives
 import spray.testkit.ScalatestRouteTest
+import spray.http.MediaTypes._
 
 @DoNotDiscover
 class ApiServiceSpec extends FlatSpec with Matchers with Directives with ScalatestRouteTest
@@ -46,6 +47,14 @@ with AgoraTestData with BeforeAndAfterAll {
       + testEntity1WithId.snapshotId.get) ~> methodsService.queryByNamespaceNameSnapshotIdRoute ~> check {
       handleError(entity.as[AgoraEntity], (entity: AgoraEntity) => assert(entity === testEntity1WithId))
       assert(status === OK)
+    }
+  }
+
+  "Agora" should "return status 404, mediaType json when nothing matches query by namespace, name, snapshotId" in {
+    Get(ApiUtil.Methods.withLeadingSlash + "/foofoofoofoo/foofoofoo/99999"
+    ) ~> methodsService.queryByNamespaceNameSnapshotIdRoute ~> check {
+      assert(status === NotFound)
+      assert(mediaType === `application/json`)
     }
   }
 


### PR DESCRIPTION
We were returning 4xx error responses in plain text format, which broke the swagger UI and hid the actual error message.

(Details: The swagger UI sends an "accepts" header requiring responses to be in JSON. That's ok for success responses, which are in JSON. But for 404 errors, for example, we were attempting to return a plain text error message. Spray tries to be smart about this, so instead of returning the plain text 404 error message, it returns a 406 to indicate that the response format does not match the "accepts" header.)