### PR TITLE
Create translator between Google ACLs and Agora permissions

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/acls/GcsRole.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/acls/GcsRole.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.agora.server.acls
+
+import org.broadinstitute.dsde.agora.server.acls.GcsRole._
+
+object GcsRole {
+  val Reader = "READER"
+  val Writer = "WRITER"
+  val Owner = "OWNER"
+  val Nothing = "NOTHING"
+}
+
+case class GcsBucketRole(role: String) {
+
+  def isReader: Boolean = role.equals(Reader) || role.equals(Writer) || role.equals(Owner)
+
+  def isWriter: Boolean = role.equals(Writer) || role.equals(Owner)
+
+  def isOwner: Boolean = role.equals(Owner)
+}
+
+case class GcsObjectRole(role: String) {
+
+  def isReader: Boolean = role.equals(Reader) || role.equals(Owner)
+
+  def isOwner: Boolean = role.equals(Owner)
+}

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/acls/RoleTranslator.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/acls/RoleTranslator.scala
@@ -1,0 +1,42 @@
+package org.broadinstitute.dsde.agora.server.acls
+
+import org.broadinstitute.dsde.agora.server.business.AgoraPermissions
+import org.broadinstitute.dsde.agora.server.business.AgoraPermissions._
+import org.broadinstitute.dsde.agora.server.acls.GcsRole._
+
+object RoleTranslator {
+
+  def gcsBucketToNamespacePermissions(bucketRole: GcsBucketRole): AgoraPermissions = {
+    bucketRole match {
+      case GcsBucketRole(Owner) => new AgoraPermissions(Read, Write, Create, Redact, Manage)
+      case GcsBucketRole(Writer) => new AgoraPermissions(Read, Write, Create, Redact)
+      case GcsBucketRole(Reader) => AgoraPermissions(Read)
+      case _ => AgoraPermissions(AgoraPermissions.Nothing) 
+    }
+  }
+
+  def gcsObjectToMethodPermissions(objectRole: GcsObjectRole): AgoraPermissions = {
+    objectRole match {
+      case GcsObjectRole(Owner) => new AgoraPermissions(Read, Manage)
+      case GcsObjectRole(Reader) => AgoraPermissions(Read)
+      case _ => AgoraPermissions(AgoraPermissions.Nothing)
+    }
+  }
+
+  def namespaceToBucketRole(namespacePermissions: AgoraPermissions): GcsBucketRole = {
+    namespacePermissions match {
+      case AgoraPermissions(Manage) => GcsBucketRole(Owner)
+      case AgoraPermissions(Write) => GcsBucketRole(Writer)
+      case AgoraPermissions(Read) => GcsBucketRole(Reader)
+      case _ => GcsBucketRole(GcsRole.Nothing)
+    }
+  }
+
+  def methodToObjectRole(methodPermissions: AgoraPermissions): GcsObjectRole = {
+    methodPermissions match {
+      case AgoraPermissions(Manage) => GcsObjectRole(Owner)
+      case AgoraPermissions(Read) => GcsObjectRole(Reader)
+      case _ => GcsObjectRole(GcsRole.Nothing)
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraPermissions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraPermissions.scala
@@ -4,6 +4,7 @@ package org.broadinstitute.dsde.agora.server.business
 import org.broadinstitute.dsde.agora.server.business.AgoraPermissions._
 
 object AgoraPermissions {
+  val Nothing = 0
   val Read = 1 << 0
   val Write = 1 << 1
   val Create = 1 << 2
@@ -13,17 +14,17 @@ object AgoraPermissions {
   val All = Read | Write | Create | Redact | Manage
 }
 
-case class AgoraAcl(permissions: Int) {
+case class AgoraPermissions(permissions: Int) {
   def this(varPermissions: Int*) {
     this(varPermissions.foldLeft(0) { (perm1, perm2) => perm1 | perm2 })
   }
 
-  def removePermissions(varPermissions: Int*): AgoraAcl = {
-    AgoraAcl(varPermissions.foldLeft(permissions) { (perm1, perm2) => perm1 & ~perm2 })
+  def removePermissions(varPermissions: Int*) = {
+    AgoraPermissions(varPermissions.foldLeft(permissions) { (perm1, perm2) => perm1 & ~perm2 })
   }
 
   def addPermissions(varPermissions: Int*) = {
-    AgoraAcl(varPermissions.foldLeft(permissions) { (perm1, perm2) => perm1 | perm2 })
+    AgoraPermissions(varPermissions.foldLeft(permissions) { (perm1, perm2) => perm1 | perm2 })
   }
 
   def canRead: Boolean = (permissions & Read) != 0

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.agora.server
 
 import com.github.simplyscala.{MongoEmbedDatabase, MongodProps}
 import com.mongodb.casbah.MongoClient
+import org.broadinstitute.dsde.agora.server.acls.RoleTranslatorTest
 import org.broadinstitute.dsde.agora.server.business.{AgoraAccessControlTest, AgoraBusiness, AgoraBusinessTest}
 import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
 import org.broadinstitute.dsde.agora.server.dataaccess.mongo.{AgoraMongoClient, MethodsDbTest}
@@ -24,7 +25,8 @@ class AgoraTestSuite extends Suites(
   new AgoraBusinessTest,
   new AgoraValidationTest,
   new AgoraApiJsonSupportTest,
-  new AgoraAccessControlTest) with AgoraTestData with BeforeAndAfterAll with MongoEmbedDatabase {
+  new AgoraAccessControlTest,
+  new RoleTranslatorTest) with AgoraTestData with BeforeAndAfterAll with MongoEmbedDatabase {
 
   var mongoProps: MongodProps = null
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/acls/RoleTranslatorTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/acls/RoleTranslatorTest.scala
@@ -1,0 +1,123 @@
+package org.broadinstitute.dsde.agora.server.acls
+
+import org.scalatest.{Matchers, FlatSpec, DoNotDiscover}
+import org.broadinstitute.dsde.agora.server.business.AgoraPermissions
+import org.broadinstitute.dsde.agora.server.business.AgoraPermissions._
+
+@DoNotDiscover
+class RoleTranslatorTest extends FlatSpec with Matchers {
+
+  "RoleTranslator" should "translate bucket Nothing -> namespace Nothing" in {
+    val bucketRole = GcsBucketRole(GcsRole.Nothing)
+    val namespacePermissions = RoleTranslator.gcsBucketToNamespacePermissions(bucketRole)
+    assert(namespacePermissions.canRead === false)
+    assert(namespacePermissions.canWrite === false)
+    assert(namespacePermissions.canCreate === false)
+    assert(namespacePermissions.canRedact === false)
+    assert(namespacePermissions.canManage === false)
+  }
+
+  "RoleTranslator" should "translate bucket READER -> namespace read" in {
+    val bucketRole = GcsBucketRole(GcsRole.Reader)
+    val namespacePermissions = RoleTranslator.gcsBucketToNamespacePermissions(bucketRole)
+    assert(namespacePermissions.canRead === true)
+    assert(namespacePermissions.canCreate === false)
+    assert(namespacePermissions.canManage === false)
+  }
+
+  "RoleTranslator" should "translate bucket WRITER -> namespace read, create" in {
+    val bucketRole = GcsBucketRole(GcsRole.Writer)
+    val namespacePermissions = RoleTranslator.gcsBucketToNamespacePermissions(bucketRole)
+    assert(namespacePermissions.canRead === true)
+    assert(namespacePermissions.canCreate === true)
+    assert(namespacePermissions.canManage === false)
+  }
+
+  "RoleTranslator" should "translate bucket OWNER -> namespace read, create, manage" in {
+    val bucketRole = GcsBucketRole(GcsRole.Owner)
+    val namespacePermissions = RoleTranslator.gcsBucketToNamespacePermissions(bucketRole)
+    assert(namespacePermissions.canRead === true)
+    assert(namespacePermissions.canCreate === true)
+    assert(namespacePermissions.canManage === true)
+  }
+
+  "RoleTranslator" should "translate object NOTHING -> no method permissions" in {
+    val objectRole = GcsObjectRole(GcsRole.Nothing)
+    val methodPermissions = RoleTranslator.gcsObjectToMethodPermissions(objectRole)
+    assert(methodPermissions.canRead === false)
+    assert(methodPermissions.canWrite === false)
+    assert(methodPermissions.canRedact === false)
+    assert(methodPermissions.canManage === false)
+  }
+
+  "RoleTranslator" should "translate object READER -> method read" in {
+    val objectRole = GcsObjectRole(GcsRole.Reader)
+    val methodPermissions = RoleTranslator.gcsObjectToMethodPermissions(objectRole)
+    assert(methodPermissions.canRead === true)
+    assert(methodPermissions.canWrite === false)
+    assert(methodPermissions.canRedact === false)
+    assert(methodPermissions.canManage === false)
+  }
+
+  "RoleTranslator" should "translate object OWNER -> method read, manage" in {
+    val objectRole = GcsObjectRole(GcsRole.Owner)
+    val methodPermissions = RoleTranslator.gcsObjectToMethodPermissions(objectRole)
+    assert(methodPermissions.canRead === true)
+    assert(methodPermissions.canWrite === false)
+    assert(methodPermissions.canRedact === false)
+    assert(methodPermissions.canManage === true)
+  }
+
+  "RoleTranslator" should "translate namespace Nothing -> bucket Nothing" in {
+    val namespacePermissions = new AgoraPermissions(AgoraPermissions.Nothing)
+    val bucketRole = RoleTranslator.namespaceToBucketRole(namespacePermissions)
+    assert(bucketRole.isReader === false)
+    assert(bucketRole.isWriter === false)
+    assert(bucketRole.isOwner === false)
+  }
+
+  "RoleTranslator" should "translate namespace(read) -> bucket READER" in {
+    val namespacePermissions = new AgoraPermissions(Read)
+    val bucketRole = RoleTranslator.namespaceToBucketRole(namespacePermissions)
+    assert(bucketRole.isReader === true)
+    assert(bucketRole.isWriter === false)
+    assert(bucketRole.isOwner === false)
+  }
+
+  "RoleTranslator" should "translate namespace(write) -> bucket WRITER" in {
+    val namespacePermissions = new AgoraPermissions(Write)
+    val bucketRole = RoleTranslator.namespaceToBucketRole(namespacePermissions)
+    assert(bucketRole.isReader === true)
+    assert(bucketRole.isWriter === true)
+    assert(bucketRole.isOwner === false)
+  }
+
+  "RoleTranslator" should "translate namespace(manage) -> bucket OWNER" in {
+    val namespacePermissions = new AgoraPermissions(Manage)
+    val bucketRole = RoleTranslator.namespaceToBucketRole(namespacePermissions)
+    assert(bucketRole.isReader === true)
+    assert(bucketRole.isWriter === true)
+    assert(bucketRole.isOwner === true)
+  }
+
+  "RoleTranslator" should "translate method Nothing -> object Nothing" in {
+    val methodPermissions = new AgoraPermissions(Nothing)
+    val objectRole = RoleTranslator.methodToObjectRole(methodPermissions)
+    assert(objectRole.isReader === false)
+    assert(objectRole.isOwner === false)
+  }
+
+  "RoleTranslator" should "translate method(read) -> object(READER)" in {
+    val methodPermissions = new AgoraPermissions(Read)
+    val objectRole = RoleTranslator.methodToObjectRole(methodPermissions)
+    assert(objectRole.isReader === true)
+    assert(objectRole.isOwner === false)
+  }
+
+  "RoleTranslator" should "translate method(manage) -> object(OWNER)" in {
+    val methodPermissions = new AgoraPermissions(Manage)
+    val objectRole = RoleTranslator.methodToObjectRole(methodPermissions)
+    assert(objectRole.isReader === true)
+    assert(objectRole.isOwner === true)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraAccessControlTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraAccessControlTest.scala
@@ -7,22 +7,22 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 @DoNotDiscover
 class AgoraAccessControlTest extends FlatSpec with Matchers {
   "Agora" should "return true if someone has read access and we ask if they have read access " in {
-    val acl = AgoraAcl(Read)
+    val acl = AgoraPermissions(Read)
     assert(acl.canRead === true)
   }
 
   "Agora" should "return true if someone has read and write access and we ask if they have read access " in {
-    val acl = AgoraAcl(ReadWrite)
+    val acl = AgoraPermissions(ReadWrite)
     assert(acl.canRead === true)
   }
 
   "Agora" should "return false if someone has read access and we ask if they have write access " in {
-    val acl = AgoraAcl(Read)
+    val acl = AgoraPermissions(Read)
     assert(acl.canWrite === false)
   }
 
   "Agora" should "return true for all permissions if they have full access" in {
-    val acl = AgoraAcl(All)
+    val acl = AgoraPermissions(All)
     assert(acl.canRead === true)
     assert(acl.canWrite === true)
     assert(acl.canCreate === true)
@@ -31,7 +31,7 @@ class AgoraAccessControlTest extends FlatSpec with Matchers {
   }
 
   "Agora" should "be able to construct an ACL using var arg permissions" in {
-    val acl = new AgoraAcl(Read, Write, Redact)
+    val acl = new AgoraPermissions(Read, Write, Redact)
     assert(acl.canRead === true)
     assert(acl.canWrite === true)
     assert(acl.canRedact === true)
@@ -40,7 +40,7 @@ class AgoraAccessControlTest extends FlatSpec with Matchers {
   }
 
   "Agora" should "be able to remove permissions from an ACL using var arg permissions" in {
-    val acl = new AgoraAcl(All)
+    val acl = new AgoraPermissions(All)
     val newAcl = acl.removePermissions(Write, Create)
     assert(newAcl.canRead === true)
     assert(newAcl.canWrite === false)
@@ -50,7 +50,7 @@ class AgoraAccessControlTest extends FlatSpec with Matchers {
   }
 
   "Agora" should "be able to add permissions from an ACL using var arg permissions" in {
-    val acl = new AgoraAcl(Read)
+    val acl = new AgoraPermissions(Read)
     val newAcl = acl.addPermissions(Write, Create)
     assert(newAcl.canRead === true)
     assert(newAcl.canWrite === true)


### PR DESCRIPTION
We have two levels of permissions: those on a namespace, and those on a method.

We populate namespace permissions solely by looking at the corresponding gcs bucket role.
We populate method permissions solely by looking at the corresponding gcs object role.

There are 5 possible permissions on both namespaces and methods (Read, Write, Create, Redact, Manage). All 5 can be populated on namespaces. For methods, only Read and Manage will ever be populated as long as we're using gcs acls as our back end (because there is no WRITER permission on object acls).

The translator does not try to model the idea that namespace Read implies method Read. It's up to callers to know that a user should be allowed to read a method if they have Read on the namespace but not on the method. Similarly, Write will never be populated on a method, and it's up to callers to check for namespace level Write to decide if the user can modify a method.