### PR TITLE
Restrict inserts to users with create permission

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/business/AuthorizationProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/business/AuthorizationProvider.scala
@@ -3,9 +3,17 @@ package org.broadinstitute.dsde.agora.server.business
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 
 trait AuthorizationProvider {
-  def authorizationsForEntity(agoraEntity: AgoraEntity, username: String): AuthorizedAgoraEntity
+  def authorizationsForEntity(agoraEntity: Option[AgoraEntity], username: String): AuthorizedAgoraEntity
 
   def authorizationsForEntities(agoraEntities: Seq[AgoraEntity], username: String): Seq[AuthorizedAgoraEntity]
+
+  def filterByReadPermissions(authEntities: Seq[AuthorizedAgoraEntity]): Seq[AgoraEntity] = {
+    authEntities.flatMap(authEntity => filterByReadPermissions(authEntity))
+  }
+
+  def filterByReadPermissions(authEntity: AuthorizedAgoraEntity): Option[AgoraEntity] = {
+    if (authEntity.authorization.canRead) authEntity.entity else None
+  }
 }
 
 

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/business/AuthorizedAgoraEntity.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/business/AuthorizedAgoraEntity.scala
@@ -3,4 +3,4 @@ package org.broadinstitute.dsde.agora.server.business
 
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 
-case class AuthorizedAgoraEntity(entity: AgoraEntity, authorization: AgoraPermissions)
+case class AuthorizedAgoraEntity(entity: Option[AgoraEntity], authorization: AgoraPermissions)

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/gcs/GcsAuthorizationProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/gcs/GcsAuthorizationProvider.scala
@@ -6,14 +6,14 @@ import org.broadinstitute.dsde.agora.server.business.{AuthorizationProvider, Ago
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 
 object GcsAuthorizationProvider extends AuthorizationProvider {
-  override def authorizationsForEntity(agoraEntity: AgoraEntity, username: String): AuthorizedAgoraEntity = {
+  override def authorizationsForEntity(agoraEntity: Option[AgoraEntity], username: String): AuthorizedAgoraEntity = {
     //TODO call google here and do GACL -> AgAcl translation
     AuthorizedAgoraEntity(agoraEntity, AgoraPermissions(All))
   }
 
   def authorizationsForEntities(agoraEntities: Seq[AgoraEntity], username: String): Seq[AuthorizedAgoraEntity] = {
     //TODO call google here and do GACL -> AgAcl translation
-    agoraEntities.map { entity => AuthorizedAgoraEntity(entity, AgoraPermissions(All)) }
+    agoraEntities.map { entity => AuthorizedAgoraEntity(Some(entity), AgoraPermissions(All)) }
   }
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestSuite.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.agora.server
 import com.github.simplyscala.{MongoEmbedDatabase, MongodProps}
 import com.mongodb.casbah.MongoClient
 import org.broadinstitute.dsde.agora.server.acls.{AgoraAuthorizationTest, RoleTranslatorTest}
-import org.broadinstitute.dsde.agora.server.business.{AgoraPermissions, AgoraBusiness, AgoraBusinessTest}
+import org.broadinstitute.dsde.agora.server.business.{AgoraBusiness, AgoraBusinessTest}
 import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
 import org.broadinstitute.dsde.agora.server.dataaccess.authorization.TestAuthorizationProvider
 import org.broadinstitute.dsde.agora.server.dataaccess.mongo.{AgoraMongoClient, MethodsDbTest}
@@ -30,7 +30,7 @@ class AgoraTestSuite extends Suites(
   new RoleTranslatorTest) with AgoraTestData with BeforeAndAfterAll with MongoEmbedDatabase {
 
   val agora = new Agora(TestAuthorizationProvider)
-  val agoraBusiness = new AgoraBusiness(TestAuthorizationProvider)
+  val agoraBusiness = new AgoraBusiness()
   var mongoProps: MongodProps = null
 
   override def beforeAll() {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/acls/AgoraAuthorizationTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/acls/AgoraAuthorizationTest.scala
@@ -64,14 +64,18 @@ class AgoraAuthorizationTest extends ApiServiceSpec {
   }
 
   "Agora" should "only return methods that have read permissions " in {
-    val agoraBusiness = new AgoraBusiness(TestAuthorizationProvider)
+    val agoraBusiness = new AgoraBusiness()
 
     TestAuthorizationProvider.addLocalPermissions(TestAuthorizationProvider.getUniqueIdentifier(testEntity1WithId), AgoraPermissions(Nothing))
-    val noEntities = agoraBusiness.find(testEntity1WithId, None, Seq(AgoraEntityType.Workflow, AgoraEntityType.Task), agoraCIOwner.get)
+    val entities = agoraBusiness.find(testEntity1WithId, None, Seq(AgoraEntityType.Workflow, AgoraEntityType.Task), agoraCIOwner.get)
+    val authorizedEntities = TestAuthorizationProvider.authorizationsForEntities(entities, agoraCIOwner.get)
+    val noEntities = TestAuthorizationProvider.filterByReadPermissions(authorizedEntities)
     assert(noEntities.size === 0)
 
     TestAuthorizationProvider.addLocalPermissions(TestAuthorizationProvider.getUniqueIdentifier(testEntity1WithId), AgoraPermissions(Read))
-    val foundEntitites = agoraBusiness.find(testEntity1WithId, None, Seq(AgoraEntityType.Workflow, AgoraEntityType.Task), agoraCIOwner.get)
-    assert(foundEntitites.size === 1)
+    val foundEntities = agoraBusiness.find(testEntity1WithId, None, Seq(AgoraEntityType.Workflow, AgoraEntityType.Task), agoraCIOwner.get)
+    val authorizedEntities2 = TestAuthorizationProvider.authorizationsForEntities(foundEntities, agoraCIOwner.get)
+    val oneEntity = TestAuthorizationProvider.filterByReadPermissions(authorizedEntities2)
+    assert(oneEntity.size === 1)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
@@ -1,14 +1,13 @@
 package org.broadinstitute.dsde.agora.server.business
 
 import org.broadinstitute.dsde.agora.server.{AgoraTestData, AgoraConfig}
-import org.broadinstitute.dsde.agora.server.dataaccess.authorization.{TestAuthorizationProvider, TestAuthorizationProvider$}
 import org.broadinstitute.dsde.agora.server.model.{AgoraEntity, AgoraEntityType}
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 
 @DoNotDiscover
 class AgoraBusinessTest extends FlatSpec with Matchers with AgoraTestData {
 
-  val agoraBusiness = new AgoraBusiness(TestAuthorizationProvider)
+  val agoraBusiness = new AgoraBusiness()
 
   "Agora" should "return an empty URL if entity namespace, name, or snapshotId are missing" in {
     val noNamespace = AgoraEntity(name = Option("test"), snapshotId = Option(12), entityType = Option(AgoraEntityType.Task))

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/authorization/TestAuthorizationProvider.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/authorization/TestAuthorizationProvider.scala
@@ -14,12 +14,16 @@ object TestAuthorizationProvider extends AuthorizationProvider {
 
   def addLocalPermissions(entityId: String, authorization: AgoraPermissions) = localPermissions.put(entityId, authorization)
 
-  override def authorizationsForEntity(agoraEntity: AgoraEntity, username: String): AuthorizedAgoraEntity = {
-    AuthorizedAgoraEntity(agoraEntity, localPermissions.getOrElse(getUniqueIdentifier(agoraEntity), AgoraPermissions(All)))
+  override def authorizationsForEntity(agoraEntity: Option[AgoraEntity], username: String): AuthorizedAgoraEntity = {
+    agoraEntity match {
+      case Some(agoraEntity) => AuthorizedAgoraEntity(Some(agoraEntity), localPermissions.getOrElse(getUniqueIdentifier(agoraEntity), AgoraPermissions(All)))
+      case None => AuthorizedAgoraEntity(None, AgoraPermissions(Nothing))
+    }
+    
   }
 
   override def authorizationsForEntities(agoraEntities: Seq[AgoraEntity], username: String): Seq[AuthorizedAgoraEntity] = {
-    agoraEntities.map { entity => AuthorizedAgoraEntity(entity, localPermissions.getOrElse(getUniqueIdentifier(entity), AgoraPermissions(All))) }
+    agoraEntities.map { entity => AuthorizedAgoraEntity(Some(entity), localPermissions.getOrElse(getUniqueIdentifier(entity), AgoraPermissions(All))) }
   }
 
   def getUniqueIdentifier(entity: AgoraEntity): String = entity.namespace + ":" + entity.name + ":" + entity.snapshotId

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.agora.server.webservice
 
 import org.broadinstitute.dsde.agora.server.AgoraTestData
 import org.broadinstitute.dsde.agora.server.business.AgoraBusiness
-import org.broadinstitute.dsde.agora.server.dataaccess.authorization.{TestAuthorizationProvider, TestAuthorizationProvider$}
-import org.broadinstitute.dsde.agora.server.model.{AgoraEntity, AgoraEntityType}
+import org.broadinstitute.dsde.agora.server.dataaccess.authorization.TestAuthorizationProvider
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.configurations.ConfigurationsService
 import org.broadinstitute.dsde.agora.server.webservice.methods.MethodsService
 import org.broadinstitute.dsde.agora.server.webservice.validation.AgoraValidationRejection
@@ -18,7 +18,7 @@ class ApiServiceSpec extends FlatSpec with Directives with ScalatestRouteTest wi
   import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
   import spray.httpx.SprayJsonSupport._
 
-  val agoraBusiness = new AgoraBusiness(TestAuthorizationProvider)
+  val agoraBusiness = new AgoraBusiness()
 
   val wrapWithRejectionHandler = handleRejections(RejectionHandler {
     case AgoraValidationRejection(validation) :: _ => complete(BadRequest, validation)


### PR DESCRIPTION
Also, move authorization checks up from the business layer to the add and query handlers. Benefits of this are:
-We don't have to pass an AuthorizationProvider all the way down to the business layer
-We don't have to throw an exception in the business layer when a user is not authorized to insert