### PR TITLE
Ignore cromwell's logback.xml to avoid sbt assembly error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,8 @@ val customMergeStrategy: String => MergeStrategy = {
     }
   case "asm-license.txt" | "overview.html" =>
     MergeStrategy.discard
+  case "logback.xml" =>
+    MergeStrategy.first
   case _ => MergeStrategy.deduplicate
 }
 


### PR DESCRIPTION
We were getting errors when doing sbt assembly because the latest cromwell snapshot jar released 6/30 includes a logback.xml file, which causes problems because agora has its own logback.xml too.