### PR TITLE
Fix embedded urls

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/AgoraConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/AgoraConfig.scala
@@ -13,7 +13,9 @@ object AgoraConfig {
   private lazy val scheme = config.as[Option[String]]("webservice.scheme").getOrElse("http")
   private lazy val host = config.as[Option[String]]("webservice.host").getOrElse("localhost")
   lazy val port = config.as[Option[Int]]("webservice.port").getOrElse(8000)
-  private lazy val baseUrl = scheme + "://" + host + ":" + port + "/"
+  private lazy val embeddedUrlPort = config.as[Option[Int]]("embeddedUrl.port")
+  private lazy val embeddedUrlPortStr = embeddedUrlPort match { case None => "" case x: Some[Int] => ":" + x.get }
+  private lazy val baseUrl = scheme + "://" + host + embeddedUrlPortStr + "/"
   lazy val methodsRoute = config.as[Option[String]]("methods.route").getOrElse("methods")
   lazy val methodsUrl = baseUrl + methodsRoute + "/"
   lazy val configurationsRoute = config.as[Option[String]]("configurations.route").getOrElse("configurations")


### PR DESCRIPTION
Our embedded urls had port 8000 in them, which is not actually what we want when agora runs behind a proxy. When we run behind a proxy we usually want to leave the port blank in the embedded url.

I created a new config parameter called embeddedUrl.port so that this can be set independently of whatever port we tell agora to bind to. So, for example we can have:
webservice.port=8000
embeddedUrl.port=443

Or we can just not specify embeddedUrl.port, in which case the port will be blank in the embedded url.

We still need the option of specifying a port in embedded urls, because people may sometimes run locally without a proxy and still want to have valid embedded urls.