### PR TITLE
google credential token now refreshes when it expires (every hour)

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/GoogleCredentialHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/GoogleCredentialHandler.scala
@@ -7,10 +7,9 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.storage.StorageScopes.DEVSTORAGE_FULL_CONTROL
+import scala.concurrent.duration._
 
 object GoogleCredentialHandler {
-
-  val one_minute = 60
 
   val credential: GoogleCredential = {
     val emailAddress = AgoraConfig.gcsServiceAccountUserEmail
@@ -29,7 +28,7 @@ object GoogleCredentialHandler {
     val expires = Option(credential.getExpiresInSeconds)
 
     expires match {
-      case Some(duration) => if (duration < one_minute) credential.refreshToken()
+      case Some(time) => if (Duration(time, SECONDS) < 1.minute) credential.refreshToken()
       case None => credential.refreshToken()
     }
     credential.getAccessToken

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/GoogleCredentialHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/GoogleCredentialHandler.scala
@@ -9,18 +9,29 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.storage.StorageScopes.DEVSTORAGE_FULL_CONTROL
 
 object GoogleCredentialHandler {
-  val accessToken: String = {
+
+  val one_minute = 60
+
+  val credential: GoogleCredential = {
     val emailAddress = AgoraConfig.gcsServiceAccountUserEmail
     val JSON_FACTORY = JacksonFactory.getDefaultInstance
     val httpTransport = GoogleNetHttpTransport.newTrustedTransport()
-    val credential = new GoogleCredential.Builder()
+    new GoogleCredential.Builder()
       .setTransport(httpTransport)
       .setJsonFactory(JSON_FACTORY)
       .setServiceAccountId(emailAddress)
       .setServiceAccountPrivateKeyFromP12File(new File(AgoraConfig.gcServiceAccountP12KeyFile))
       .setServiceAccountScopes(Collections.singleton(DEVSTORAGE_FULL_CONTROL))
       .build()
-    credential.refreshToken()
+  }
+
+  def accessToken: String = {
+    val expires = Option(credential.getExpiresInSeconds)
+
+    expires match {
+      case Some(duration) => if (duration < one_minute) credential.refreshToken()
+      case None => credential.refreshToken()
+    }
     credential.getAccessToken
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/gcs/GcsAuthorizationProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/gcs/GcsAuthorizationProvider.scala
@@ -30,7 +30,7 @@ object GcsAuthorizationProvider extends AuthorizationProvider with LazyLogging {
   val removeEtagHeaders: HttpResponse => HttpResponse =
     r => r.withHeaders(r.headers.filter(!_.name.startsWith("ETag")))
 
-  val pipeline = addCredentials(OAuth2BearerToken(GoogleCredentialHandler.accessToken)) ~> sendReceive ~> removeEtagHeaders
+  def pipeline = addCredentials(OAuth2BearerToken(GoogleCredentialHandler.accessToken)) ~> sendReceive ~> removeEtagHeaders
 
   private case class GoogleResponse(entity: AgoraEntity, response: HttpResponse)
 


### PR DESCRIPTION
Quick fix to make the GoogleCredential token refresh when it expires. Pipeline has been changed to a function so the token will be checked before every call to Google.