### PR TITLE
Fix unmarshalling when OpenAm user's email is empty

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
@@ -48,6 +48,25 @@ object AgoraApiJsonSupport extends DefaultJsonProtocol {
     }
   }
 
+  implicit object UserInfoResponseFormat extends RootJsonFormat[UserInfoResponse] {
+    override def write(userInfo: UserInfoResponse) = {
+      JsObject("username" -> JsString(userInfo.username), "cn" -> userInfo.cn.toJson, "mail" -> userInfo.mail.toJson)
+    }
+
+    override def read(json: JsValue): UserInfoResponse = json match {
+      case x: JsObject =>
+        val username = x.fields("username").convertTo[String]
+        val cn = x.fields("cn").convertTo[Seq[String]]
+        val mailJson = x.fields.get("mail")
+        val mail = mailJson match {
+          case Some(mailJson) => mailJson.convertTo[Seq[String]]
+          case None => Seq.empty[String]
+        }
+        UserInfoResponse(username, cn, mail)
+      case _ => throw new DeserializationException("only string supported")
+    }
+  }
+
   private val parserISO: DateTimeFormatter = {
     ISODateTimeFormat.dateTimeNoMillis()
   }
@@ -57,6 +76,4 @@ object AgoraApiJsonSupport extends DefaultJsonProtocol {
   implicit val AgoraEntityProjectionFormat = jsonFormat2(AgoraEntityProjection)
 
   implicit val AgoraErrorFormat = jsonFormat1(AgoraError)
-
-  implicit val UserInfoResponseFormat = jsonFormat3(UserInfoResponse)
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupportTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupportTest.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.agora.server.model
 
-import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport.AgoraValidationFormat
+import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport.{UserInfoResponseFormat, AgoraValidationFormat}
+import org.broadinstitute.dsde.agora.server.webservice.util.AgoraOpenAMClient.UserInfoResponse
 import org.broadinstitute.dsde.agora.server.webservice.validation.AgoraValidation
 import org.scalatest.{DoNotDiscover, FlatSpec}
 import spray.json._
@@ -8,7 +9,7 @@ import spray.json._
 @DoNotDiscover
 class AgoraApiJsonSupportTest extends FlatSpec with DefaultJsonProtocol {
 
-  "Agora" should "convert AgoraValidation to JSON" in {
+  "AgoraApiJsonSupport" should "convert AgoraValidation to JSON" in {
     val validation = AgoraValidation(Seq("test1", "test2"))
     val json = AgoraValidationFormat.write(validation)
     val error = json.asJsObject.fields("error")
@@ -16,10 +17,27 @@ class AgoraApiJsonSupportTest extends FlatSpec with DefaultJsonProtocol {
     assert(error.toString().contains("test2") === true)
   }
 
-  "Agora" should "convert JSON to AgoraValidation" in {
+  "AgoraApiJsonSupport" should "convert JSON to AgoraValidation" in {
     val json = Map("error" -> Seq("test1", "test2")).toJson
     val validation = AgoraValidationFormat.read(json)
     assert(validation.messages.contains("test1") === true)
     assert(validation.messages.contains("test2") === true)
   }
+
+  "AgoraApiJsonSupport" should "convert UserInfoResponse to JSON and back when mail is not empty" in {
+    val userInfo = UserInfoResponse("user1", Seq("cn1", "cn2"), Seq("email1", "email2"))
+    val userInfoFromRead = UserInfoResponseFormat.read(userInfo.toJson)
+    assert(userInfoFromRead.username === "user1")
+    assert(userInfoFromRead.cn === Seq("cn1", "cn2"))
+    assert(userInfoFromRead.mail === Seq("email1", "email2"))
+  }
+
+  "AgoraApiJsonSupport" should "convert UserInfoResponse to JSON and back when mail is empty" in {
+    val userInfo = UserInfoResponse("user1", Seq("cn1", "cn2"), Seq())
+    val userInfoFromRead = UserInfoResponseFormat.read(userInfo.toJson)
+    assert(userInfoFromRead.username === "user1")
+    assert(userInfoFromRead.cn === Seq("cn1", "cn2"))
+    assert(userInfoFromRead.mail === Seq())
+  }
+
 }


### PR DESCRIPTION
Agora was blowing up when requests were coming from a OpenAM test user with no email set. We may want to block such users, but we shouldn't do it by blowing up. This pull request adds a custom json format that can deal with the empty email field.