### PR TITLE
Improvements to agora testing

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -7,6 +7,30 @@ instance.name = "reference"
 mongodb.host = "localhost"
 mongodb.port = 27017
 
+environment = "local"
+prod {
+  useOpenAMAuthentication = true
+  useStandaloneMongo = true
+  useGcsAuthorizationProvider = true
+}
+ci {
+  useOpenAMAuthentication = true
+  useStandaloneMongo = true
+  useGcsAuthorizationProvider = true
+}
+dev {
+  useOpenAMAuthentication = true
+  useStandaloneMongo = true
+  useGcsAuthorizationProvider = true
+}
+local {
+  useOpenAMAuthentication = false
+  useStandaloneMongo = false
+  useGcsAuthorizationProvider = false
+  // If not using openAMAuthentication, you need to supply a mock authenticated email.
+  mockAuthenticatedUserEmail = "broadprometheustest@gmail.com"
+}
+
 swagger {
   apiDocs = "api-docs"
   apiVersion = "0.1"

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/Agora.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/Agora.scala
@@ -1,21 +1,19 @@
 package org.broadinstitute.dsde.agora.server
 
 import com.typesafe.scalalogging.slf4j.LazyLogging
-import org.broadinstitute.dsde.agora.server.dataaccess.acls.AuthorizationProvider
-import org.broadinstitute.dsde.agora.server.dataaccess.acls.gcs.GcsAuthorizationProvider
 
-object ProductionAgora extends Agora(GcsAuthorizationProvider) with App {
+object EnvironmentSpecificAgora extends Agora(AgoraConfig.environment) with App {
     start()
 }
 
-class Agora(authorizationProvider: AuthorizationProvider) extends LazyLogging with App {
-  lazy val server: ServerInitializer = new ServerInitializer()
+class Agora(environment: String) extends LazyLogging with App {
+  lazy val server: ServerInitializer = new ServerInitializer(environment)
 
   sys addShutdownHook stop()
 
   def start() {
-    server.startAllServices(authorizationProvider)
-    logger.info("Agora instance " + AgoraConfig.serverInstanceName + " initialized.")
+    server.startAllServices()
+    logger.info("Agora instance " + AgoraConfig.serverInstanceName + " initialized, Environment: " + environment)
   }
 
   def stop() {

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/MockAuthorizationProvider.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/MockAuthorizationProvider.scala
@@ -1,15 +1,14 @@
 
-package org.broadinstitute.dsde.agora.server.dataaccess.authorization
+package org.broadinstitute.dsde.agora.server.dataaccess.acls
 
 import org.broadinstitute.dsde.agora.server.dataaccess.acls.AgoraPermissions._
-import org.broadinstitute.dsde.agora.server.dataaccess.acls.{AgoraPermissions, AuthorizationProvider}
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 
 import scala.collection.mutable
 
 //Test authorization implementation. Add authorizations directly to the hash map for lookup.
 // If no local permissions exist, full authorization is granted.
-object TestAuthorizationProvider extends AuthorizationProvider {
+object MockAuthorizationProvider extends AuthorizationProvider {
 
   // local permission storage.
   val entityPermissions = new mutable.HashMap[String, AgoraPermissions]()

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/routes/MockAgoraDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/routes/MockAgoraDirectives.scala
@@ -1,0 +1,19 @@
+package org.broadinstitute.dsde.agora.server.webservice.routes
+
+import org.broadinstitute.dsde.agora.server.AgoraConfig
+import org.broadinstitute.dsde.vault.common.directives.OpenAMDirectives
+import org.broadinstitute.dsde.vault.common.util.ImplicitMagnet
+import spray.routing.Directives._
+import spray.routing._
+
+import scala.concurrent.ExecutionContext
+
+trait MockAgoraDirectives extends AgoraDirectives {
+  def commonNameFromCookie(magnet: ImplicitMagnet[ExecutionContext]): Directive1[String] = {
+    provide(AgoraConfig.mockAuthenticatedUserEmail.split("@")(0))
+  }
+
+  def usernameFromCookie(magnet: ImplicitMagnet[ExecutionContext]): Directive1[String] = {
+    provide(AgoraConfig.mockAuthenticatedUserEmail)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraIntegrationTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraIntegrationTestSuite.scala
@@ -1,15 +1,15 @@
 
 package org.broadinstitute.dsde.agora.server
 
+import org.broadinstitute.dsde.agora.server.dataaccess.acls.GcsAuthorizationSpec
 import org.broadinstitute.dsde.agora.server.dataaccess.acls.gcs.GcsAuthorizationProvider
-import org.broadinstitute.dsde.agora.server.dataaccess.authorization.GcsAuthorizationSpec
 import org.broadinstitute.dsde.agora.server.dataaccess.mongo.EmbeddedMongo
 import org.scalatest.{BeforeAndAfterAll, Suites}
 
 class AgoraIntegrationTestSuite extends Suites(
   new GcsAuthorizationSpec) with BeforeAndAfterAll {
-  val agora = new Agora(GcsAuthorizationProvider)
-
+  val agora = new Agora(AgoraConfig.DevEnvironment)     // Integration Tests use the dev environment settings
+                                                        // AgoraOpenAMDirectives, GcsAuthorizationProvider, non-embedded Mongo
   override def beforeAll() {
     println(s"Starting Agora web services ($suiteName)")
     agora.start()

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraUnitTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraUnitTestSuite.scala
@@ -2,8 +2,7 @@ package org.broadinstitute.dsde.agora.server
 
 import org.broadinstitute.dsde.agora.server.AgoraTestData._
 import org.broadinstitute.dsde.agora.server.business.{AgoraBusiness, AgoraBusinessTest}
-import org.broadinstitute.dsde.agora.server.dataaccess.acls.{AgoraAuthorizationTest, RoleTranslatorTest}
-import org.broadinstitute.dsde.agora.server.dataaccess.authorization.TestAuthorizationProvider
+import org.broadinstitute.dsde.agora.server.dataaccess.acls.{MockAuthorizationProvider, AgoraAuthorizationTest, RoleTranslatorTest}
 import org.broadinstitute.dsde.agora.server.dataaccess.mongo.{EmbeddedMongo, MethodsDbTest}
 import org.broadinstitute.dsde.agora.server.model.{AgoraApiJsonSupportTest, AgoraEntityTest}
 import org.broadinstitute.dsde.agora.server.webservice._
@@ -21,23 +20,24 @@ class AgoraUnitTestSuite extends Suites(
   new AgoraAuthorizationTest,
   new RoleTranslatorTest) with BeforeAndAfterAll {
 
-  val agora = new Agora(TestAuthorizationProvider)
-  val agoraBusiness = new AgoraBusiness(TestAuthorizationProvider)
+  val agora = new Agora(AgoraConfig.LocalEnvironment)     // Unit Tests use the local environment settings
+                                                          // mockAuthentication, mockAuthorization, embedded Mongo
+  val agoraBusiness = new AgoraBusiness(MockAuthorizationProvider)
 
   override def beforeAll() {
     EmbeddedMongo.startMongo()
     println(s"Starting Agora web services ($suiteName)")
     agora.start()
 
-    TestAuthorizationProvider.createEntityAuthorizations(testEntity1, agoraCIOwner.get)
-    TestAuthorizationProvider.createEntityAuthorizations(testEntity2, agoraCIOwner.get)
-    TestAuthorizationProvider.createEntityAuthorizations(testEntity3, agoraCIOwner.get)
-    TestAuthorizationProvider.createEntityAuthorizations(testEntity4, agoraCIOwner.get)
-    TestAuthorizationProvider.createEntityAuthorizations(testEntity5, agoraCIOwner.get)
-    TestAuthorizationProvider.createEntityAuthorizations(testEntity6, agoraCIOwner.get)
-    TestAuthorizationProvider.createEntityAuthorizations(testEntity7, agoraCIOwner.get)
-    TestAuthorizationProvider.createEntityAuthorizations(testEntityTaskWc, agoraCIOwner.get)
-    TestAuthorizationProvider.createEntityAuthorizations(testAgoraConfigurationEntity, agoraCIOwner.get)
+    MockAuthorizationProvider.createEntityAuthorizations(testEntity1, agoraCIOwner.get)
+    MockAuthorizationProvider.createEntityAuthorizations(testEntity2, agoraCIOwner.get)
+    MockAuthorizationProvider.createEntityAuthorizations(testEntity3, agoraCIOwner.get)
+    MockAuthorizationProvider.createEntityAuthorizations(testEntity4, agoraCIOwner.get)
+    MockAuthorizationProvider.createEntityAuthorizations(testEntity5, agoraCIOwner.get)
+    MockAuthorizationProvider.createEntityAuthorizations(testEntity6, agoraCIOwner.get)
+    MockAuthorizationProvider.createEntityAuthorizations(testEntity7, agoraCIOwner.get)
+    MockAuthorizationProvider.createEntityAuthorizations(testEntityTaskWc, agoraCIOwner.get)
+    MockAuthorizationProvider.createEntityAuthorizations(testAgoraConfigurationEntity, agoraCIOwner.get)
 
     agoraBusiness.insert(testEntity1, agoraCIOwner.get)
     agoraBusiness.insert(testEntity2, agoraCIOwner.get)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
@@ -1,14 +1,14 @@
 package org.broadinstitute.dsde.agora.server.business
 
 import org.broadinstitute.dsde.agora.server.AgoraTestData._
-import org.broadinstitute.dsde.agora.server.dataaccess.authorization.TestAuthorizationProvider
+import org.broadinstitute.dsde.agora.server.dataaccess.acls.MockAuthorizationProvider
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 
 @DoNotDiscover
 class AgoraBusinessTest extends FlatSpec with Matchers {
 
-  val agoraBusiness = new AgoraBusiness(TestAuthorizationProvider)
-  val methodImportResolver = new MethodImportResolver(agoraCIOwner.get, agoraBusiness, TestAuthorizationProvider)
+  val agoraBusiness = new AgoraBusiness(MockAuthorizationProvider)
+  val methodImportResolver = new MethodImportResolver(agoraCIOwner.get, agoraBusiness, MockAuthorizationProvider)
 
   "Agora" should "not find a method payload when resolving a WDL import statement if the method has not been added" in {
     val importString = "methods://broad.nonexistent.5400"

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/AgoraAuthorizationTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/AgoraAuthorizationTest.scala
@@ -4,8 +4,7 @@ package org.broadinstitute.dsde.agora.server.dataaccess.acls
 import org.broadinstitute.dsde.agora.server.AgoraTestData._
 import org.broadinstitute.dsde.agora.server.business.AgoraBusiness
 import org.broadinstitute.dsde.agora.server.dataaccess.acls.AgoraPermissions._
-import org.broadinstitute.dsde.agora.server.dataaccess.authorization.TestAuthorizationProvider
-import org.broadinstitute.dsde.agora.server.dataaccess.authorization.TestAuthorizationProvider._
+import MockAuthorizationProvider._
 import org.broadinstitute.dsde.agora.server.model.AgoraEntityType
 import org.broadinstitute.dsde.agora.server.webservice.ApiServiceSpec
 import org.scalatest.DoNotDiscover
@@ -66,7 +65,7 @@ class AgoraAuthorizationTest extends ApiServiceSpec {
   }
 
   "Agora" should "only authorize users with permissions in local permission storage" in {
-    val agoraBusiness = new AgoraBusiness(TestAuthorizationProvider)
+    val agoraBusiness = new AgoraBusiness(MockAuthorizationProvider)
 
     val agoraEntity = agoraBusiness.findSingle(testEntity1WithId.namespace.get,
                                                testEntity1WithId.name.get,
@@ -94,7 +93,7 @@ class AgoraAuthorizationTest extends ApiServiceSpec {
 
   "Agora" should "only return entities that can be read by user" in {
 
-    val agoraBusiness = new AgoraBusiness(TestAuthorizationProvider)
+    val agoraBusiness = new AgoraBusiness(MockAuthorizationProvider)
     val entities = agoraBusiness.find(testEntity1WithId, None, Seq(AgoraEntityType.Workflow, AgoraEntityType.Task), agoraCIOwner.get)
 
     // Without agoraCIOwner's permissions

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/GcsAuthorizationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/GcsAuthorizationSpec.scala
@@ -1,5 +1,5 @@
 
-package org.broadinstitute.dsde.agora.server.dataaccess.authorization
+package org.broadinstitute.dsde.agora.server.dataaccess.acls
 
 import org.broadinstitute.dsde.agora.server.AgoraConfig
 import org.broadinstitute.dsde.agora.server.AgoraIntegrationTestData._

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraImportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraImportSpec.scala
@@ -5,7 +5,7 @@ import cromwell.parser.WdlParser.SyntaxError
 import org.broadinstitute.dsde.agora.server.AgoraTestData._
 import org.broadinstitute.dsde.agora.server.business.{ImportResolverHelper, MethodImportResolver}
 import org.broadinstitute.dsde.agora.server.dataaccess.AgoraEntityNotFoundException
-import org.broadinstitute.dsde.agora.server.dataaccess.authorization.TestAuthorizationProvider
+import org.broadinstitute.dsde.agora.server.dataaccess.acls.MockAuthorizationProvider
 import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.util.ApiUtil
@@ -100,14 +100,14 @@ class AgoraImportSpec extends ApiServiceSpec {
 
   "MethodImportResolver" should "reject import if scheme != methods://" in {
     val uri = "blah://"
-    val resolver = MethodImportResolver(agoraCIOwner.get, agoraBusiness, TestAuthorizationProvider)
+    val resolver = MethodImportResolver(agoraCIOwner.get, agoraBusiness, MockAuthorizationProvider)
     val thrown = the[SyntaxError] thrownBy resolver.importResolver(uri)
     assert(thrown.getMessage.contains("start with") === true)
   }
 
   "MethodImportResolver" should "throw an AgoraEntityNotFoundException if method not found" in {
     val uri = "methods://foo.bar.22"
-    val resolver = MethodImportResolver(agoraCIOwner.get, agoraBusiness, TestAuthorizationProvider)
+    val resolver = MethodImportResolver(agoraCIOwner.get, agoraBusiness, MockAuthorizationProvider)
     val thrown = intercept[AgoraEntityNotFoundException] {
       resolver.importResolver(uri)
     }
@@ -119,7 +119,7 @@ class AgoraImportSpec extends ApiServiceSpec {
     val name = testEntityTaskWcWithId.name.get
     val id = testEntityTaskWcWithId.snapshotId.get
     val uri = s"methods://$namespace.$name.$id"
-    val resolver = MethodImportResolver(agoraCIOwner.get, agoraBusiness, TestAuthorizationProvider)
+    val resolver = MethodImportResolver(agoraCIOwner.get, agoraBusiness, MockAuthorizationProvider)
     val payload = resolver.importResolver(uri)
     assert(payload.contains("wc") === true)
   }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.agora.server.webservice
 
 import org.broadinstitute.dsde.agora.server.AgoraTestData._
 import org.broadinstitute.dsde.agora.server.business.AgoraBusiness
-import org.broadinstitute.dsde.agora.server.dataaccess.authorization.TestAuthorizationProvider
+import org.broadinstitute.dsde.agora.server.dataaccess.acls.MockAuthorizationProvider
 import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.configurations.ConfigurationsService
 import org.broadinstitute.dsde.agora.server.webservice.methods.MethodsService
@@ -15,7 +15,7 @@ import spray.testkit.ScalatestRouteTest
 @DoNotDiscover
 class ApiServiceSpec extends FlatSpec with Directives with ScalatestRouteTest with BeforeAndAfterAll {
 
-  val agoraBusiness = new AgoraBusiness(TestAuthorizationProvider)
+  val agoraBusiness = new AgoraBusiness(MockAuthorizationProvider)
 
   val wrapWithExceptionHandler = handleExceptions(ExceptionHandler {
     case e: IllegalArgumentException => complete(BadRequest, e.getMessage)
@@ -58,8 +58,8 @@ class ApiServiceSpec extends FlatSpec with Directives with ScalatestRouteTest wi
       agoraCIOwner.get).head
   }
 
-  val methodsService = new MethodsService(TestAuthorizationProvider) with ActorRefFactoryContext with AgoraOpenAMMockDirectives
-  val configurationsService = new ConfigurationsService(TestAuthorizationProvider) with ActorRefFactoryContext with AgoraOpenAMMockDirectives
+  val methodsService = new MethodsService(MockAuthorizationProvider) with ActorRefFactoryContext with AgoraOpenAMMockDirectives
+  val configurationsService = new ConfigurationsService(MockAuthorizationProvider) with ActorRefFactoryContext with AgoraOpenAMMockDirectives
 
   def handleError[T](deserialized: Deserialized[T], assertions: (T) => Unit) = {
     if (status.isSuccess) {


### PR DESCRIPTION
Load and validate environment (local, dev, ci, prod) from typesafe config

conditionally use embeddedMongo based on environment (only if local)
Refactored to move MockAuthorizationProvider (nee TestAuthorizationProvider) from test to src.
Select gcsAuthorizationProvider or mockAuthorizationProvider based on environment (i.e. local uses mock).
Passed environment to Agora object so that unitTest and integrationTest could use different environments for their configuration.
Pushed env-specific initialization down to ServerInitializer and ApiServiceActor.