### PR TITLE
Validate that a docker image referenced in WDL payload validates

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/AddHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/AddHandler.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.agora.server.dataaccess.acls.AuthorizationProvide
 import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
 import org.broadinstitute.dsde.agora.server.model.{AgoraEntity, AgoraError}
 import org.broadinstitute.dsde.agora.server.webservice.PerRequest.RequestComplete
+import org.broadinstitute.dsde.agora.server.webservice.util.DockerHubClient.DockerImageNotFoundException
 import org.broadinstitute.dsde.agora.server.webservice.util.ServiceMessages
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
@@ -27,7 +28,8 @@ class AddHandler(authorizationProvider: AuthorizationProvider) extends Actor {
       try {
         add(requestContext, agoraAddRequest, username)
       } catch {
-        case e: SyntaxError => context.parent ! RequestComplete(BadRequest, AgoraError("Syntax error in payload: " + e.getMessage))
+        case se: SyntaxError => context.parent ! RequestComplete(BadRequest, AgoraError("Syntax error in payload: " + se.getMessage))
+        case de: DockerImageNotFoundException => context.parent ! RequestComplete(BadRequest, AgoraError("Invalid Docker Referenced in payload: " + de.getMessage))
       }
       context.stop(self)
   }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/DockerHubClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/DockerHubClient.scala
@@ -1,0 +1,62 @@
+package org.broadinstitute.dsde.agora.server.webservice.util
+
+import akka.actor.ActorSystem
+import spray.client.pipelining._
+import spray.http.HttpResponse
+import spray.http.StatusCodes._
+import org.broadinstitute.dsde.agora.server.webservice.util.DockerHubJsonSupport._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+case class DockerImageReference(user: Option[String], repo: String, tag: String)
+
+case class DockerTagInfo(pk: Int, id: String)
+
+object DockerHubClient {
+  case class DockerConnectionException(text: String = "There was a problem connecting to Docker Hub APIs.") extends Exception(text)
+
+  case class DockerImageNotFoundException(dockerImage: DockerImageReference) extends Exception {
+    override def getMessage: String = {
+      s"Docker Image for User ${dockerImage.user.getOrElse("'Official'")}/" + s"${dockerImage.repo}" + s":${dockerImage.tag} not found."
+    }
+  }
+
+  implicit val actorSystem = ActorSystem("agora")
+
+  import actorSystem.dispatcher
+
+  val timeout = 5.seconds
+
+  def pipeline = sendReceive
+
+  def dcGET(url: String): Future[HttpResponse] = pipeline(Get(url))
+
+  def doesDockerImageExist(dockerImage: DockerImageReference): Boolean = {
+    val dockerImageInfo = dcGET(dockerImageTagUrl(dockerImage))
+
+    val dockerTagExists = dockerImageInfo map { response: HttpResponse =>
+      response.status match {
+        case OK => unmarshal[List[DockerTagInfo]].apply(response).nonEmpty
+        case NotFound => throw new DockerImageNotFoundException(dockerImage)
+        case _ => throw new DockerImageNotFoundException(dockerImage)
+      }
+    }
+
+    dockerImageInfo.onFailure { case _ => throw DockerImageNotFoundException(dockerImage) }
+    val isDockerImageInfoFound = Await.result(dockerTagExists, timeout)
+    isDockerImageInfoFound
+  }
+
+  val dockerImageRepositoryBaseUrl = "https://index.docker.io/v1/repositories/"
+  def dockerImageTagUrl(dockerImage: DockerImageReference) = {
+    var url = dockerImageRepositoryBaseUrl
+    if (dockerImage.user.isDefined) {
+      url += dockerImage.user.get + "/"
+    }
+    url += dockerImage.repo + "/tags/" + dockerImage.tag
+    url
+  }
+
+}
+

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/DockerHubJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/DockerHubJsonSupport.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsde.agora.server.webservice.util
+
+import spray.httpx.SprayJsonSupport
+import spray.json.DefaultJsonProtocol
+
+object DockerHubJsonSupport extends DefaultJsonProtocol with SprayJsonSupport {
+  implicit val DockerTagInfoFormat = jsonFormat2(DockerTagInfo)
+}

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraIntegrationTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraIntegrationTestData.scala
@@ -23,6 +23,66 @@ object AgoraIntegrationTestData  {
                                             payload = payload1,
                                             entityType = Option(AgoraEntityType.Workflow))
 
+  val testAgoraEntityWithValidOfficialDockerImageInWdl = new AgoraEntity(namespace = Option("___docker_test" + System.currentTimeMillis()),
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = Option(owner1),
+    payload = payloadWithValidOfficialDockerImageInWdl,
+    entityType = Option(AgoraEntityType.Task)
+  )
 
+  val testAgoraEntityWithInvalidOfficialDockerRepoNameInWdl = new AgoraEntity(namespace = Option("___docker_test" + System.currentTimeMillis()),
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = Option(owner1),
+    payload = payloadWithInvalidOfficialDockerRepoNameInWdl,
+    entityType = Option(AgoraEntityType.Task)
+  )
 
+  val testAgoraEntityWithInvalidOfficialDockerTagNameInWdl = new AgoraEntity(namespace = Option("___docker_test" + System.currentTimeMillis()),
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = Option(owner1),
+    payload = payloadWithInvalidOfficialDockerTagNameInWdl,
+    entityType = Option(AgoraEntityType.Task)
+  )
+
+  val testAgoraEntityWithValidPersonalDockerInWdl = new AgoraEntity(namespace = Option("___docker_test" + System.currentTimeMillis()),
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = Option(owner1),
+    payload = payloadWithValidPersonalDockerImageInWdl,
+    entityType = Option(AgoraEntityType.Task)
+  )
+
+  val testAgoraEntityWithInvalidPersonalDockerUserNameInWdl = new AgoraEntity(namespace = Option("___docker_test" + System.currentTimeMillis()),
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = Option(owner1),
+    payload = payloadWithInvalidPersonalDockerUserNameInWdl,
+    entityType = Option(AgoraEntityType.Task)
+  )
+
+  val testAgoraEntityWithInvalidPersonalDockerRepoNameInWdl = new AgoraEntity(namespace = Option("___docker_test" + System.currentTimeMillis()),
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = Option(owner1),
+    payload = payloadWithInvalidPersonalDockerRepoNameInWdl,
+    entityType = Option(AgoraEntityType.Task)
+  )
+
+  val testAgoraEntityWithInvalidPersonalDockerTagNameInWdl = new AgoraEntity(namespace = Option("___docker_test" + System.currentTimeMillis()),
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = Option(owner1),
+    payload = payloadWithInvalidPersonalDockerTagNameInWdl,
+    entityType = Option(AgoraEntityType.Task)
+  )
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraIntegrationTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraIntegrationTestSuite.scala
@@ -1,17 +1,21 @@
 
 package org.broadinstitute.dsde.agora.server
 
+import org.broadinstitute.dsde.agora.server.business.AgoraBusinessIntegrationSpec
 import org.broadinstitute.dsde.agora.server.dataaccess.acls.GcsAuthorizationSpec
-import org.broadinstitute.dsde.agora.server.dataaccess.acls.gcs.GcsAuthorizationProvider
 import org.broadinstitute.dsde.agora.server.dataaccess.mongo.EmbeddedMongo
 import org.broadinstitute.dsde.agora.server.webservice.AclIntegrationSpec
+import org.broadinstitute.dsde.agora.server.webservice.AgoraImportIntegrationSpec
 import org.scalatest.{BeforeAndAfterAll, Suites}
 
 class AgoraIntegrationTestSuite extends Suites(
   new GcsAuthorizationSpec,
-  new AclIntegrationSpec) with BeforeAndAfterAll {
-  val agora = new Agora(AgoraConfig.DevEnvironment)
-
+  new AclIntegrationSpec,
+  new AgoraBusinessIntegrationSpec,
+  new AgoraImportIntegrationSpec
+) with BeforeAndAfterAll {
+  val agora = new Agora(AgoraConfig.DevEnvironment)     // Integration Tests use the dev environment settings
+                                                        // AgoraOpenAMDirectives, GcsAuthorizationProvider, non-embedded Mongo
   override def beforeAll() {
     println(s"Starting Agora web services ($suiteName)")
     agora.start()

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -173,7 +173,106 @@ object AgoraTestData {
                                     |  },
                                     |  "namespace": "ns"
                                     |}""".stripMargin)
-
+  val payloadWithValidOfficialDockerImageInWdl = Option( """
+                                    |task wc {
+                                    |  command {
+                                    |    wc -l ${sep=' ' File files+} | tail -1 | cut -d' ' -f 2
+                                    |  }
+                                    |  output {
+                                    |    Int count = read_int("stdout")
+                                    |  }
+                                    |  runtime {
+                                    |    docker: "ubuntu:latest"
+                                    |  }
+                                    |}
+                                    | """.stripMargin)
+  val payloadWithInvalidOfficialDockerRepoNameInWdl = Option( """
+                                                                |task wc {
+                                                                |  command {
+                                                                |    wc -l ${sep=' ' File files+} | tail -1 | cut -d' ' -f 2
+                                                                |  }
+                                                                |  output {
+                                                                |    Int count = read_int("stdout")
+                                                                |  }
+                                                                |  runtime {
+                                                                |    docker: "ubuntu_doesnotexist:latest"
+                                                                |  }
+                                                                |}
+                                                                | """.stripMargin)
+  val payloadWithInvalidOfficialDockerTagNameInWdl = Option( """
+                                                             |task wc {
+                                                             |  command {
+                                                             |    wc -l ${sep=' ' File files+} | tail -1 | cut -d' ' -f 2
+                                                             |  }
+                                                             |  output {
+                                                             |    Int count = read_int("stdout")
+                                                             |  }
+                                                             |  runtime {
+                                                             |    docker: "ubuntu:ggrant_latest"
+                                                             |  }
+                                                             |}
+                                                             | """.stripMargin)
+  val payloadWithValidPersonalDockerImageInWdl = Option( """
+                                                           |task wc {
+                                                           |  command {
+                                                           |    wc -l ${sep=' ' File files+} | tail -1 | cut -d' ' -f 2
+                                                           |  }
+                                                           |  output {
+                                                           |    Int count = read_int("stdout")
+                                                           |  }
+                                                           |  runtime {
+                                                           |    docker: "broadinstitute/scala-baseimage"
+                                                           |  }
+                                                           |}
+                                                           | """.stripMargin)
+  val payloadWithInvalidPersonalDockerUserNameInWdl = Option( """
+                                                               |task wc {
+                                                               |  command {
+                                                               |    wc -l ${sep=' ' File files+} | tail -1 | cut -d' ' -f 2
+                                                               |  }
+                                                               |  output {
+                                                               |    Int count = read_int("stdout")
+                                                               |  }
+                                                               |  runtime {
+                                                               |    docker: "broadinstitute_doesnotexist/scala-baseimage:latest"
+                                                               |    memory: "2MB"
+                                                               |    cores: 1
+                                                               |    disk: "3MB"
+                                                               |  }
+                                                               |}
+                                                               | """.stripMargin)
+  val payloadWithInvalidPersonalDockerRepoNameInWdl = Option( """
+                                                                |task wc {
+                                                                |  command {
+                                                                |    wc -l ${sep=' ' File files+} | tail -1 | cut -d' ' -f 2
+                                                                |  }
+                                                                |  output {
+                                                                |    Int count = read_int("stdout")
+                                                                |  }
+                                                                |  runtime {
+                                                                |    docker: "broadinstitute/scala-baseimage_doesnotexist:latest"
+                                                                |    memory: "2MB"
+                                                                |    cores: 1
+                                                                |    disk: "3MB"
+                                                                |  }
+                                                                |}
+                                                                | """.stripMargin)
+  val payloadWithInvalidPersonalDockerTagNameInWdl = Option( """
+                                                                |task wc {
+                                                                |  command {
+                                                                |    wc -l ${sep=' ' File files+} | tail -1 | cut -d' ' -f 2
+                                                                |  }
+                                                                |  output {
+                                                                |    Int count = read_int("stdout")
+                                                                |  }
+                                                                |  runtime {
+                                                                |    docker: "broadinstitute/scala-baseimage:latest_doesnotexist"
+                                                                |    memory: "2MB"
+                                                                |    cores: 1
+                                                                |    disk: "3MB"
+                                                                |  }
+                                                                |}
+                                                                | """.stripMargin)
   val testEntity1 = AgoraEntity(namespace = namespace1,
     name = name1,
     synopsis = synopsis1,
@@ -277,6 +376,15 @@ object AgoraTestData {
     owner = owner1,
     payload = badPayloadNonExistentImport,
     entityType = Option(AgoraEntityType.Workflow)
+  )
+
+  val testAgoraEntityWithInvalidOfficialDockerImageInWdl = new AgoraEntity(namespace = namespace1,
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = owner1,
+    payload = payloadWithInvalidOfficialDockerTagNameInWdl,
+    entityType = Option(AgoraEntityType.Task)
   )
 
   val testEntityWorkflowWithExistentWdlImport = new AgoraEntity(

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessIntegrationSpec.scala
@@ -1,0 +1,57 @@
+package org.broadinstitute.dsde.agora.server.business
+
+import org.broadinstitute.dsde.agora.server.AgoraConfig
+import org.broadinstitute.dsde.agora.server.AgoraIntegrationTestData._
+import org.broadinstitute.dsde.agora.server.dataaccess.acls.gcs.GcsAuthorizationProvider
+import org.broadinstitute.dsde.agora.server.webservice.util.DockerHubClient.DockerImageNotFoundException
+import org.scalatest.{DoNotDiscover, FlatSpec}
+
+@DoNotDiscover
+class AgoraBusinessIntegrationSpec extends FlatSpec {
+  val agoraBusiness = new AgoraBusiness(GcsAuthorizationProvider)
+
+  "Agora" should "be able to store a task configuration with a valid (extant) official docker image" in {
+    val entity = agoraBusiness.insert(testAgoraEntityWithValidOfficialDockerImageInWdl, owner1)
+    assert(agoraBusiness.findSingle(entity, Seq(entity.entityType.get), owner1) === entity)
+  }
+
+  "Agora" should "be unable to store a task configuration with an invalid docker image (invalid/non-existent repo name)" in {
+    val thrown = intercept[DockerImageNotFoundException] {
+      agoraBusiness.insert(testAgoraEntityWithInvalidOfficialDockerRepoNameInWdl, owner1)
+    }
+    assert(thrown != null)
+  }
+
+  "Agora" should "be unable to store a task configuration with an invalid docker image (invalid/non-existent tag name)" in {
+    val thrown = intercept[DockerImageNotFoundException] {
+      agoraBusiness.insert(testAgoraEntityWithInvalidOfficialDockerTagNameInWdl, owner1)
+    }
+    assert(thrown != null)
+  }
+
+  "Agora" should "be able to store a task configuration with a valid (extant) personal docker image" in {
+    val entity = agoraBusiness.insert(testAgoraEntityWithValidPersonalDockerInWdl, owner1)
+    assert(agoraBusiness.findSingle(entity, Seq(entity.entityType.get), owner1) === entity)
+  }
+
+  "Agora" should "be unable to store a task configuration with an invalid personal docker image (invalid/non-existent user name)" in {
+    val thrown = intercept[DockerImageNotFoundException] {
+      agoraBusiness.insert(testAgoraEntityWithInvalidPersonalDockerUserNameInWdl, owner1)
+    }
+    assert(thrown != null)
+  }
+
+  "Agora" should "be unable to store a task configuration with an invalid personal docker image (invalid/non-existent repo name)" in {
+    val thrown = intercept[DockerImageNotFoundException] {
+      agoraBusiness.insert(testAgoraEntityWithInvalidPersonalDockerRepoNameInWdl, owner1)
+    }
+    assert(thrown != null)
+  }
+
+  "Agora" should "be unable to store a task configuration with an invalid personal docker image (invalid/non-existent tag name)" in {
+    val thrown = intercept[DockerImageNotFoundException] {
+      agoraBusiness.insert(testAgoraEntityWithInvalidPersonalDockerTagNameInWdl, owner1)
+    }
+    assert(thrown != null)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/GcsAuthorizationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/acls/GcsAuthorizationSpec.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.agora.server.dataaccess.acls
 
 import org.broadinstitute.dsde.agora.server.AgoraIntegrationTestData._
 import org.broadinstitute.dsde.agora.server.business.{EntityAuthorizationException, AgoraBusiness}
-import org.broadinstitute.dsde.agora.server.dataaccess.acls.AgoraPermissions.{Nothing}
+import org.broadinstitute.dsde.agora.server.dataaccess.acls.AgoraPermissions.Nothing
 import org.broadinstitute.dsde.agora.server.dataaccess.acls.gcs.GcsAuthorizationProvider
 import org.scalatest.{DoNotDiscover, FlatSpec}
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraImportIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraImportIntegrationSpec.scala
@@ -1,0 +1,115 @@
+package org.broadinstitute.dsde.agora.server.webservice
+
+import org.broadinstitute.dsde.agora.server.AgoraIntegrationTestData._
+import org.broadinstitute.dsde.agora.server.business.AgoraBusiness
+import org.broadinstitute.dsde.agora.server.dataaccess.acls.MockAuthorizationProvider
+import org.broadinstitute.dsde.agora.server.model.AgoraEntity
+import org.broadinstitute.dsde.agora.server.webservice.methods.MethodsService
+import org.broadinstitute.dsde.agora.server.webservice.util.ApiUtil
+import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, DoNotDiscover}
+import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
+import spray.httpx.unmarshalling._
+import spray.testkit.{ScalatestRouteTest, RouteTest}
+import scala.concurrent.duration._
+
+@DoNotDiscover
+class AgoraImportIntegrationSpec extends FlatSpec with RouteTest with ScalatestRouteTest with BeforeAndAfterAll {
+
+  implicit val routeTestTimeout = RouteTestTimeout(20.seconds)
+
+  trait ActorRefFactoryContext {
+    def actorRefFactory = system
+  }
+
+  val agoraBusiness = new AgoraBusiness(MockAuthorizationProvider)
+  val methodsService = new MethodsService(MockAuthorizationProvider) with ActorRefFactoryContext with AgoraOpenAMMockDirectives
+
+
+  def handleError[T](deserialized: Deserialized[T], assertions: (T) => Unit) = {
+    if (status.isSuccess) {
+      if (deserialized.isRight) assertions(deserialized.right.get) else failTest(deserialized.left.get.toString)
+    } else {
+      failTest(response.message.toString)
+    }
+  }
+
+  "MethodsService" should "return a 201 when posting a WDL with a valid (extant) official docker image" in {
+    Post(ApiUtil.Methods.withLeadingSlash, testAgoraEntityWithValidOfficialDockerImageInWdl) ~>
+      methodsService.postRoute ~> check {
+      handleError(entity.as[AgoraEntity], (entity: AgoraEntity) => {
+        assert(entity.namespace === testAgoraEntityWithValidOfficialDockerImageInWdl.namespace)
+        assert(entity.name === testAgoraEntityWithValidOfficialDockerImageInWdl.name)
+        assert(entity.synopsis === testAgoraEntityWithValidOfficialDockerImageInWdl.synopsis)
+        assert(entity.documentation === testAgoraEntityWithValidOfficialDockerImageInWdl.documentation)
+        assert(entity.owner === testAgoraEntityWithValidOfficialDockerImageInWdl.owner)
+        assert(entity.payload === testAgoraEntityWithValidOfficialDockerImageInWdl.payload)
+        assert(entity.snapshotId !== None)
+        assert(entity.createDate !== None)
+      })
+      assert(status === Created)
+    }
+  }
+
+  "MethodsService" should "return a 400 bad request when posting a WDL with an invalid official docker image (invalid/non-existent repo name)" in {
+    Post(ApiUtil.Methods.withLeadingSlash, testAgoraEntityWithInvalidOfficialDockerRepoNameInWdl) ~>
+      methodsService.postRoute ~> check {
+      assert(status === BadRequest)
+      assert(responseAs[String] != null)
+    }
+  }
+
+  "MethodsService" should "return a 400 bad request when posting a WDL with an invalid official docker image (invalid/non-existent tag name)" in {
+    Post(ApiUtil.Methods.withLeadingSlash, testAgoraEntityWithInvalidOfficialDockerTagNameInWdl) ~>
+      methodsService.postRoute ~> check {
+      assert(status === BadRequest)
+      assert(responseAs[String] != null)
+    }
+  }
+
+  "MethodsService" should "return a 201 when posting a WDL with a valid (extant) personal docker image" in {
+    Post(ApiUtil.Methods.withLeadingSlash, testAgoraEntityWithValidPersonalDockerInWdl) ~>
+      methodsService.postRoute ~> check {
+      handleError(entity.as[AgoraEntity], (entity: AgoraEntity) => {
+        assert(entity.namespace === testAgoraEntityWithValidPersonalDockerInWdl.namespace)
+        assert(entity.name === testAgoraEntityWithValidPersonalDockerInWdl.name)
+        assert(entity.synopsis === testAgoraEntityWithValidPersonalDockerInWdl.synopsis)
+        assert(entity.documentation === testAgoraEntityWithValidPersonalDockerInWdl.documentation)
+        assert(entity.owner === testAgoraEntityWithValidPersonalDockerInWdl.owner)
+        assert(entity.payload === testAgoraEntityWithValidPersonalDockerInWdl.payload)
+        assert(entity.snapshotId !== None)
+        assert(entity.createDate !== None)
+      })
+      assert(status === Created)
+    }
+  }
+
+  "MethodsService" should "return a 400 bad request when posting a WDL with an invalid personal docker image (invalid/non-existent user name)" in {
+    Post(ApiUtil.Methods.withLeadingSlash, testAgoraEntityWithInvalidPersonalDockerUserNameInWdl) ~>
+      methodsService.postRoute ~> check {
+      assert(status === BadRequest)
+      assert(responseAs[String] != null)
+    }
+  }
+
+  "MethodsService" should "return a 400 bad request when posting a WDL with an invalid personal docker image (invalid/non-existent repo name)" in {
+    Post(ApiUtil.Methods.withLeadingSlash, testAgoraEntityWithInvalidPersonalDockerRepoNameInWdl) ~>
+      methodsService.postRoute ~> check {
+      assert(status === BadRequest)
+      assert(responseAs[String] != null)
+    }
+  }
+
+  "MethodsService" should "return a 400 bad request when posting a WDL with an invalid personal docker image (invalid/non-existent tag name)" in {
+    Post(ApiUtil.Methods.withLeadingSlash, testAgoraEntityWithInvalidPersonalDockerTagNameInWdl) ~>
+      methodsService.postRoute ~> check {
+      assert(status === BadRequest)
+      assert(responseAs[String] != null)
+    }
+  }
+
+
+
+
+}


### PR DESCRIPTION
Validate that a docker image referenced in WDL payload validates (that it exists in docker hub).

Validate that if WDL contains a docker reference and it is properly formatted,
that the docker image exists.  Dealt with both 'official' and 'personal'
docker hub images and optional tags.  Added integration tests.