### PR TITLE
Add reference from Configuration to Method

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/AgoraMongoClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/AgoraMongoClient.scala
@@ -34,6 +34,12 @@ object AgoraMongoClient {
     mongoClient(AgoraConfig.mongoDbDatabase)(ConfigurationsCollection)
   }
 
+  def getCollectionsByEntityType(entityTypes: Seq[AgoraEntityType.EntityType]): Seq[MongoCollection] = {
+    entityTypes.flatMap {
+      entityType => getCollectionsByEntityType(Option(entityType))
+    }
+  }
+
   def getCollectionsByEntityType(entityType: Option[AgoraEntityType.EntityType]): Seq[MongoCollection] = {
     entityType match {
       case Some(AgoraEntityType.Task) =>

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.agora.server.model
 
 import org.broadinstitute.dsde.agora.server.webservice.util.AgoraOpenAMClient.UserInfoResponse
 import org.broadinstitute.dsde.agora.server.dataaccess.permissions.{AgoraPermissions, AccessControl}
+import org.bson.types.ObjectId
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormatter, ISODateTimeFormat}
 import spray.json._
@@ -15,6 +16,16 @@ object AgoraApiJsonSupport extends DefaultJsonProtocol {
 
   implicit def stringToType(str: String): AgoraEntityType.EntityType = AgoraEntityType.withName(str)
 
+  implicit object ObjectIdJsonFormat extends RootJsonFormat[ObjectId] {
+    override def write(obj: ObjectId) = {
+      JsObject("$oid" -> JsString(obj.toHexString))
+    }
+
+    override def read(json: JsValue): ObjectId = {
+      new ObjectId(json.asJsObject.fields("$oid").convertTo[String])
+    }
+  }
+  
   implicit object DateJsonFormat extends RootJsonFormat[DateTime] {
     override def write(obj: DateTime) = {
       JsString(parserISO.print(obj))
@@ -54,8 +65,57 @@ object AgoraApiJsonSupport extends DefaultJsonProtocol {
     }
   }
 
-  private val parserISO: DateTimeFormatter = {
-    ISODateTimeFormat.dateTimeNoMillis()
+  implicit object AgoraEntityFormat extends RootJsonFormat[AgoraEntity] {
+  
+    override def write(entity: AgoraEntity) = {
+      var map = Map.empty[String, JsValue]
+      if (entity.namespace.nonEmpty) map += ("namespace" -> JsString(entity.namespace.get))
+      if (entity.name.nonEmpty) map += ("name" -> JsString(entity.name.get))
+      if (entity.snapshotId.nonEmpty) map += ("snapshotId" -> JsNumber(entity.snapshotId.get))
+      if (entity.synopsis.nonEmpty) map += ("synopsis" -> JsString(entity.synopsis.get))
+      if (entity.documentation.nonEmpty) map += ("documentation" -> JsString(entity.documentation.get))
+      if (entity.owner.nonEmpty) map += ("owner" -> JsString(entity.owner.get))
+      if (entity.createDate.nonEmpty) map += ("createDate" -> entity.createDate.get.toJson)
+      if (entity.payload.nonEmpty) map += ("payload" -> JsString(entity.payload.get))
+      if (entity.url.nonEmpty) map += ("url" -> JsString(entity.url.get))
+      if (entity.entityType.nonEmpty) map += ("entityType" -> entity.entityType.get.toJson)
+      if (entity.id.nonEmpty) map += ("_id" -> entity.id.get.toJson)
+      if (entity.methodId.nonEmpty) map += ("methodId" -> entity.methodId.get.toJson)
+      if (entity.method.nonEmpty) map += ("method" -> entity.method.get.toJson)
+      JsObject(map)
+    }
+
+    override def read(json: JsValue): AgoraEntity = {
+      val jsObject = json.asJsObject
+      val namespace = stringOrNone(jsObject, "namespace")
+      val name = stringOrNone(jsObject, "name")
+      val snapshotId = if (jsObject.getFields("snapshotId").nonEmpty) jsObject.fields("snapshotId").convertTo[Option[Int]] else None
+      val synopsis = stringOrNone(jsObject, "synopsis")
+      val documentation = stringOrNone(jsObject, "documentation")
+      val owner = stringOrNone(jsObject, "owner")
+      val createDate = if (jsObject.getFields("createDate").nonEmpty) jsObject.fields("createDate").convertTo[Option[DateTime]] else None
+      val payload = stringOrNone(jsObject, "payload")
+      val url = stringOrNone(jsObject, "url")
+      val entityType = if (jsObject.getFields("entityType").nonEmpty) jsObject.fields("entityType").convertTo[Option[AgoraEntityType.EntityType]] else None
+      val id = if (jsObject.getFields("_id").nonEmpty) jsObject.fields("_id").convertTo[Option[ObjectId]] else None
+      val methodId = if (jsObject.getFields("methodId").nonEmpty) jsObject.fields("methodId").convertTo[Option[ObjectId]] else None
+      val method = if (jsObject.getFields("method").nonEmpty) jsObject.fields("method").convertTo[Option[AgoraEntity]] else None
+
+      val entity = AgoraEntity(namespace = namespace,
+                               name = name,
+                               snapshotId = snapshotId,
+                               synopsis = synopsis,
+                               documentation = documentation,
+                               owner = owner,
+                               createDate = createDate,
+                               payload = payload,
+                               url = url,
+                               entityType = entityType,
+                               id = id,
+                               methodId = methodId,
+                               method = method)
+      entity
+    }
   }
 
   implicit object AgoraPermissionsFormat extends RootJsonFormat[AgoraPermissions] {
@@ -71,8 +131,23 @@ object AgoraApiJsonSupport extends DefaultJsonProtocol {
 
   }
 
-  implicit val AgoraEntityFormat = jsonFormat10(AgoraEntity.apply)
+  def methodRef(payload: String): AgoraEntity = {
+    val json = payload.parseJson
+    val refJson = json.asJsObject.fields("methodStoreMethod").asJsObject
+    val namespace = refJson.fields("methodNamespace").convertTo[String]
+    val name = refJson.fields("methodName").convertTo[String]
+    val snapshotId = refJson.fields("methodVersion").convertTo[Int]
+    AgoraEntity(namespace = Option(namespace), name = Option(name), snapshotId = Option(snapshotId))
+  }
 
+  private def stringOrNone(json: JsObject, key: String): Option[String] = {
+    if (json.getFields(key).nonEmpty) json.fields(key).convertTo[Option[String]] else None
+  }
+  
+  private val parserISO: DateTimeFormatter = {
+    ISODateTimeFormat.dateTimeNoMillis()
+  }
+  
   implicit val AgoraEntityProjectionFormat = jsonFormat2(AgoraEntityProjection.apply)
 
   implicit val AgoraErrorFormat = jsonFormat1(AgoraError)

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.agora.server.model
 
 import com.wordnik.swagger.annotations.{ApiModel, ApiModelProperty}
 import org.broadinstitute.dsde.agora.server.AgoraConfig
+import org.bson.types.ObjectId
 import org.joda.time.DateTime
 
 import scala.annotation.meta.field
@@ -19,6 +20,7 @@ object AgoraEntityType extends Enumeration {
   val Task = Value("Task")
   val Workflow = Value("Workflow")
   val Configuration = Value("Configuration")
+  val MethodTypes = Seq(Task, Workflow)
 }
 
 object AgoraEntity {
@@ -102,7 +104,10 @@ case class AgoraEntity(namespace: Option[String] = None,
                        createDate: Option[DateTime] = None,
                        payload: Option[String] = None,
                        url: Option[String] = None,
-                       entityType: Option[AgoraEntityType.EntityType] = None) {
+                       entityType: Option[AgoraEntityType.EntityType] = None,
+                       id: Option[ObjectId] = None,
+                       methodId: Option[ObjectId] = None,
+                       method: Option[AgoraEntity] = None) {
 
   AgoraEntity.validate(this) match {
     case Success(_) => this
@@ -119,6 +124,22 @@ case class AgoraEntity(namespace: Option[String] = None,
 
   def addDate(): AgoraEntity = {
     copy(createDate = Option(new DateTime()))
+  }
+  
+  def addMethodId(methodId: String): AgoraEntity = {
+    copy(methodId = Option(new ObjectId(methodId)))
+  }
+
+  def addMethod(method: Option[AgoraEntity]): AgoraEntity = {
+    copy(method = method)
+  }
+  
+  def removeIds(): AgoraEntity = {
+    copy(id = None, methodId = None)
+  }
+
+  def addEntityType(entityType: Option[AgoraEntityType.EntityType]): AgoraEntity = {
+    copy(entityType = entityType)
   }
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraService.scala
@@ -94,12 +94,11 @@ abstract class AgoraService extends HttpService with RouteHelpers {
   def postRoute =
     postPath(path) { (username) =>
       entity(as[AgoraEntity]) { agoraEntity =>
-        validateEntityType(agoraEntity, path) {
-          requestContext => completeWithPerRequest(requestContext, agoraEntity, username, addHandlerProps)
+        validatePostRoute(agoraEntity, path) {
+          requestContext => completeWithPerRequest(requestContext, agoraEntity, username, path, addHandlerProps)
         }
       }
     }
-
 }
 
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -154,11 +154,11 @@ object AgoraTestData {
                                               |
                                               | """.stripMargin)
 
-  val taskConfigPayload = Option( """{
-                                    |  "method": {
-                                    |    "name": "method",
-                                    |    "namespace": "method_ns",
-                                    |    "version": "1"
+  val taskConfigPayload = Option( s"""{
+                                    |  "methodStoreMethod": {
+                                    |    "methodNamespace": "${namespace1.get}",
+                                    |    "methodName": "${name1.get}",
+                                    |    "methodVersion": 1
                                     |  },
                                     |  "name": "first",
                                     |  "workspaceName": {
@@ -177,6 +177,31 @@ object AgoraTestData {
                                     |  },
                                     |  "namespace": "ns"
                                     |}""".stripMargin)
+
+  val taskConfigPayload2 = Option( s"""{
+                                    |  "methodStoreMethod": {
+                                    |    "methodNamespace": "${namespace2.get}",
+                                    |    "methodName": "${name1.get}",
+                                    |    "methodVersion": 1
+                                    |  },
+                                    |  "name": "first",
+                                    |  "workspaceName": {
+                                    |    "namespace": "foo",
+                                    |    "name": "bar"
+                                    |  },
+                                    |  "outputs": {
+                                    |
+                                    |  },
+                                    |  "inputs": {
+                                    |    "p": "hi"
+                                    |  },
+                                    |  "rootEntityType": "sample",
+                                    |  "prerequisites": {
+                                    |
+                                    |  },
+                                    |  "namespace": "ns"
+                                    |}""".stripMargin)
+
   val payloadWithValidOfficialDockerImageInWdl = Option( """
                                     |task wc {
                                     |  command {
@@ -422,6 +447,16 @@ object AgoraTestData {
   )
 
   val testAgoraConfigurationEntity2 = new AgoraEntity(
+    namespace = namespace3,
+    name = name2,
+    synopsis = synopsis3,
+    documentation = documentation1,
+    owner = owner1,
+    payload = taskConfigPayload2,
+    entityType = Option(AgoraEntityType.Configuration)
+  )
+
+  val testAgoraConfigurationEntity3 = new AgoraEntity(
     namespace = namespace2,
     name = name1,
     synopsis = synopsis3,

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraUnitTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraUnitTestSuite.scala
@@ -57,6 +57,7 @@ class AgoraUnitTestSuite extends Suites(
     agoraBusiness.insert(testEntity7, mockAutheticatedOwner.get)
     agoraBusiness.insert(testEntityTaskWc, mockAutheticatedOwner.get)
     agoraBusiness.insert(testAgoraConfigurationEntity, mockAutheticatedOwner.get)
+    agoraBusiness.insert(testAgoraConfigurationEntity2, mockAutheticatedOwner.get)
   }
 
   override def afterAll() {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraConfigurationsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraConfigurationsSpec.scala
@@ -1,20 +1,42 @@
 
 package org.broadinstitute.dsde.agora.server.webservice
 
+import org.broadinstitute.dsde.agora.server.AgoraConfig
+import org.broadinstitute.dsde.agora.server.dataaccess.AgoraDao
+import org.broadinstitute.dsde.agora.server.dataaccess.permissions.{AccessControl, AgoraEntityPermissionsClient, AgoraPermissions}
 import org.broadinstitute.dsde.agora.server.model.AgoraApiJsonSupport._
-import org.broadinstitute.dsde.agora.server.model.AgoraEntity
+import org.broadinstitute.dsde.agora.server.model.{AgoraEntityType, AgoraEntity}
 import org.broadinstitute.dsde.agora.server.webservice.util.ApiUtil
 import org.scalatest.DoNotDiscover
 import org.broadinstitute.dsde.agora.server.AgoraTestData._
+import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.httpx.unmarshalling._
 import spray.routing.ValidationRejection
 
 @DoNotDiscover
 class AgoraConfigurationsSpec extends ApiServiceSpec {
+
+  var method1: AgoraEntity = _
+  var origPermission: AgoraPermissions = _
+  var origAccessControl: AccessControl = _
+
+  override def beforeAll() = {
+    method1 = AgoraDao.createAgoraDao(AgoraEntityType.MethodTypes).find(testEntity1).head
+    origPermission = AgoraEntityPermissionsClient.getEntityPermission(method1, AgoraConfig.mockAuthenticatedUserEmail)
+    origAccessControl = new AccessControl(AgoraConfig.mockAuthenticatedUserEmail, origPermission)
+  }
+
+  override def afterAll() = {
+    AgoraEntityPermissionsClient.editEntityPermission(method1, origAccessControl)
+  }
+
   "Agora" should "be able to store a task configuration" in {
-    Post(ApiUtil.Configurations.withLeadingSlash, testAgoraConfigurationEntity2) ~>
+    Post(ApiUtil.Configurations.withLeadingSlash, testAgoraConfigurationEntity3) ~>
       configurationsService.postRoute ~> check {
+
+      val referencedMethod = AgoraDao.createAgoraDao(AgoraEntityType.MethodTypes).findSingle(namespace1.get, name1.get, snapshotId1.get)
+
       handleError(entity.as[AgoraEntity], (entity: AgoraEntity) => {
         assert(entity.namespace === namespace2)
         assert(entity.name === name1)
@@ -24,10 +46,83 @@ class AgoraConfigurationsSpec extends ApiServiceSpec {
         assert(entity.payload === taskConfigPayload)
         assert(entity.snapshotId !== None)
         assert(entity.createDate !== None)
+        assert(referencedMethod.id !== None)
+        assert(entity.method !== None)
+
+        val foundMethod = entity.method.get
+        assert(foundMethod.namespace === namespace1)
+        assert(foundMethod.name === name1)
+        assert(foundMethod.snapshotId === snapshotId1)
+        assert(foundMethod.url !== None)
       })
     }
   }
 
+  "Agora" should "populate method references when returning configurations" in {
+    Get(ApiUtil.Configurations.withLeadingSlash) ~>
+      configurationsService.queryRoute ~> check {
+
+      handleError(entity.as[Seq[AgoraEntity]], (configs: Seq[AgoraEntity]) => {
+        assert(configs.size === 3)
+
+        val method1 = AgoraDao.createAgoraDao(AgoraEntityType.MethodTypes).findSingle(namespace1.get, name1.get, snapshotId1.get)
+        val method2 = AgoraDao.createAgoraDao(AgoraEntityType.MethodTypes).findSingle(namespace2.get, name1.get, snapshotId1.get)
+        val method3 = AgoraDao.createAgoraDao(AgoraEntityType.MethodTypes).findSingle(namespace1.get, name1.get, snapshotId1.get)
+
+        val config1 = AgoraDao.createAgoraDao(Seq(AgoraEntityType.Configuration)).findSingle(
+          testAgoraConfigurationEntity.namespace.get, testAgoraConfigurationEntity.name.get, 2)
+        val config2 = AgoraDao.createAgoraDao(Seq(AgoraEntityType.Configuration)).findSingle(
+          testAgoraConfigurationEntity2.namespace.get, testAgoraConfigurationEntity2.name.get, 1)
+        val config3 = AgoraDao.createAgoraDao(Seq(AgoraEntityType.Configuration)).findSingle(
+          testAgoraConfigurationEntity3.namespace.get, testAgoraConfigurationEntity3.name.get, 2)
+
+        val foundConfig1 = configs.find(config => namespaceNameIdMatch(config, config1)).get
+        val foundConfig2 = configs.find(config => namespaceNameIdMatch(config, config2)).get
+        val foundConfig3 = configs.find(config => namespaceNameIdMatch(config, config3)).get
+        
+        val methodRef1 = foundConfig1.method.get
+        val methodRef2 = foundConfig2.method.get
+        val methodRef3 = foundConfig3.method.get
+
+        assert(methodRef1.namespace !== None)
+        assert(methodRef1.name !== None)
+        assert(methodRef1.snapshotId !== None)
+        assert(methodRef2.namespace !== None)
+        assert(methodRef2.name !== None)
+        assert(methodRef2.snapshotId !== None)
+        assert(methodRef3.namespace !== None)
+        assert(methodRef3.name !== None)
+        assert(methodRef3.snapshotId !== None)
+
+        assert(methodRef1.namespace === method1.namespace)
+        assert(methodRef1.name === method1.name)
+        assert(methodRef1.snapshotId === method1.snapshotId)
+        assert(methodRef2.namespace === method2.namespace)
+        assert(methodRef2.name === method2.name)
+        assert(methodRef2.snapshotId === method2.snapshotId)
+        assert(methodRef3.namespace === method3.namespace)
+        assert(methodRef3.name === method3.name)
+        assert(methodRef3.snapshotId === method3.snapshotId)
+      })
+
+    }
+  }
+
+  "Agora" should "not allow you to post a new configuration if you don't have permission to read the method that it references" in {
+    val noPermission = new AccessControl(AgoraConfig.mockAuthenticatedUserEmail, AgoraPermissions(AgoraPermissions.Nothing))
+    AgoraEntityPermissionsClient.editEntityPermission(method1, noPermission)
+    Post(ApiUtil.Configurations.withLeadingSlash, testAgoraConfigurationEntity3) ~>
+      configurationsService.postRoute ~> check {
+        assert(status === NotFound)
+    }
+  }
+
+  private def namespaceNameIdMatch(entity1: AgoraEntity, entity2: AgoraEntity): Boolean = {
+    entity1.namespace == entity2.namespace &&
+    entity1.name == entity2.name &&
+    entity1.snapshotId == entity2.snapshotId
+  }
+  
   "Agora" should "not allow you to post a new task to the configurations route" in {
     Post(ApiUtil.Configurations.withLeadingSlash, testEntityTaskWc) ~>
     configurationsService.postRoute ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -81,7 +81,8 @@ class ApiServiceSpec extends FlatSpec with Directives with ScalatestRouteTest wi
         owner = entity.owner,
         url = entity.url,
         createDate = entity.createDate,
-        entityType = entity.entityType
+        entityType = entity.entityType,
+        id = entity.id
       )
     )
   }


### PR DESCRIPTION
When Agora gets a query for configurations, we need to return not only the configuration but also info about the associated method. This pull request implements that functionality.

Changes:
-When inserting a configuration, find the method reference in the payload and use it to populate the methodId metadata field in the configuration
-When returning configurations, use the methodId field to find the associated method and embed its details in the configuration json