### PR TITLE
Small bug fix to configuration validation

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
@@ -106,7 +106,7 @@ class AgoraBusiness {
         namespace.tasks.foreach { validateDockerImage }
       case AgoraEntityType.Configuration =>
         val json = agoraEntity.payload.get.parseJson
-        val fields = json.asJsObject.getFields("methodStoreMethod")
+        val fields = json.asJsObject.getFields("methodRepoMethod")
         require(fields.size == 1)
         val subFields = fields(0).asJsObject.getFields("methodNamespace", "methodName", "methodVersion")
         require(subFields(0).isInstanceOf[JsString])


### PR DESCRIPTION
Rawls changed the configuration payload field "methodStoreMethod" to "methodRepoMethod"
We check for the existence of this field during validation, and we were checking by the old name.