### PR TITLE
Small bug fix to configuration validation

### DIFF
--- a/src/main/resources/swagger/agora.json
+++ b/src/main/resources/swagger/agora.json
@@ -1507,7 +1507,7 @@
         "payload": {
           "type": "string",
           "description": "Payload of method -- must be in WDL format",
-          "default": "{ \"methodStoreMethod\": { \"methodNamespace\": \"YOUR_NAMESPACE\", \"methodName\": \"BWA\", \"methodVersion\": 1}}\n"
+          "default": "{ \"methodRepoMethod\": { \"methodNamespace\": \"YOUR_NAMESPACE\", \"methodName\": \"BWA\", \"methodVersion\": 1}}\n"
         },
         "entityType": {
           "type": "string",
@@ -1556,7 +1556,7 @@
         "payload": {
           "type": "string",
           "description": "Payload of method -- must be in WDL format. MUST BE REQUESTED EXPLICITLY.",
-          "default": "{ \"methodStoreMethod\": { \"methodNamespace\": \"YOUR_NAMESPACE\", \"methodName\": \"BWA\", \"methodVersion\": 1}}\n"
+          "default": "{ \"methodRepoMethod\": { \"methodNamespace\": \"YOUR_NAMESPACE\", \"methodName\": \"BWA\", \"methodVersion\": 1}}\n"
         },
         "entityType": {
           "type": "string",

--- a/src/main/resources/swagger/agora.yaml
+++ b/src/main/resources/swagger/agora.yaml
@@ -1055,7 +1055,7 @@ definitions:
         type: string
         description: Payload of method -- must be in WDL format
         default: >
-          { "methodStoreMethod": { "methodNamespace": "YOUR_NAMESPACE",
+          { "methodRepoMethod": { "methodNamespace": "YOUR_NAMESPACE",
           "methodName": "BWA", "methodVersion": 1}}
       entityType:
         type: string
@@ -1097,7 +1097,7 @@ definitions:
         type: string
         description: Payload of method -- must be in WDL format. MUST BE REQUESTED EXPLICITLY.
         default: >
-          { "methodStoreMethod": { "methodNamespace": "YOUR_NAMESPACE",
+          { "methodRepoMethod": { "methodNamespace": "YOUR_NAMESPACE",
           "methodName": "BWA", "methodVersion": 1}}
       entityType:
         type: string

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/exceptions/ValidationException.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/exceptions/ValidationException.scala
@@ -2,6 +2,6 @@ package org.broadinstitute.dsde.agora.server.exceptions
 
 import com.typesafe.scalalogging.slf4j.LazyLogging
 
-case class PermissionNotFoundException(message: String = "Could not find permissions.", ex: Throwable = null) extends Exception with LazyLogging {
+case class ValidationException(message: String, ex: Throwable = null) extends Exception with LazyLogging {
   override def getMessage: String = message
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraApiJsonSupport.scala
@@ -144,7 +144,7 @@ object AgoraApiJsonSupport extends DefaultJsonProtocol {
 
   def methodRef(payload: String): AgoraEntity = {
     val json = payload.parseJson
-    val refJson = json.asJsObject.fields("methodStoreMethod").asJsObject
+    val refJson = json.asJsObject.fields("methodRepoMethod").asJsObject
     val namespace = refJson.fields("methodNamespace").convertTo[String]
     val name = refJson.fields("methodName").convertTo[String]
     val snapshotId = refJson.fields("methodVersion").convertTo[Int]

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/PerRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/PerRequest.scala
@@ -80,6 +80,9 @@ trait PerRequest extends Actor {
       case e: SyntaxError =>
         r.complete(BadRequest, AgoraException(e.getMessage, e.getCause, BadRequest))
         Stop
+      case e: ValidationException =>
+        r.complete(BadRequest,AgoraException(e.getMessage, e.getCause, BadRequest))
+        Stop
       case e: Throwable =>
         r.complete(InternalServerError, AgoraException(e.getMessage, e.getCause, InternalServerError))
         Stop

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -171,7 +171,7 @@ object AgoraTestData {
                                               | """.stripMargin)
 
   val taskConfigPayload = Option( s"""{
-                                    |  "methodStoreMethod": {
+                                    |  "methodRepoMethod": {
                                     |    "methodNamespace": "${namespace1.get}",
                                     |    "methodName": "${name1.get}",
                                     |    "methodVersion": 1
@@ -195,7 +195,7 @@ object AgoraTestData {
                                     |}""".stripMargin)
 
   val taskConfigPayload2 = Option( s"""{
-                                    |  "methodStoreMethod": {
+                                    |  "methodRepoMethod": {
                                     |    "methodNamespace": "${namespace2.get}",
                                     |    "methodName": "${name1.get}",
                                     |    "methodVersion": 1
@@ -220,7 +220,7 @@ object AgoraTestData {
 
 
   val taskConfigPayload3 = Option( s"""{
-                                      |  "methodStoreMethod": {
+                                      |  "methodRepoMethod": {
                                       |    "methodNamespace": "${namespace3.get}",
                                       |    "methodName": "${name3.get}",
                                       |    "methodVersion": 1


### PR DESCRIPTION
Rawls changed the configuration payload field "methodStoreMethod" to "methodRepoMethod"
We check for the existence of this field during validation, and we were checking by the old name.

Added better failure descriptions to our require statements