### PR TITLE
Removed supervisor error logging for tests.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -9,6 +9,7 @@ mongodb.port = 27017
 
 environment = "local"
 mockAuthenticatedUserEmail = "broadprometheustest@gmail.com"
+supervisor.logging = false
 
 swagger {
   apiDocs = "api-docs"
@@ -27,6 +28,7 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
 }
 
+kamon.instrumentation = false
 kamon.internal-config {
   akka {
     loglevel = INFO

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/Agora.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/Agora.scala
@@ -7,13 +7,13 @@ object ProductionAgora extends Agora {
     start()
 }
 
-class Agora extends LazyLogging with App {
+class Agora() extends LazyLogging with App {
   lazy val server: ServerInitializer = new ServerInitializer()
 
   sys addShutdownHook stop()
 
   def start() {
-    Kamon.start()
+    if (AgoraConfig.kamonInstrumentation) Kamon.start()
     server.startAllServices()
     logger.info("Agora instance " + AgoraConfig.serverInstanceName + " initialized, Environment: " + AgoraConfig.environment)
   }
@@ -22,7 +22,7 @@ class Agora extends LazyLogging with App {
     logger.info("Stopping server...")
     server.stopAllServices()
     logger.info("Server stopped.")
-    Kamon.shutdown()
+    if (AgoraConfig.kamonInstrumentation) Kamon.shutdown()
   }
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/AgoraConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/AgoraConfig.scala
@@ -65,6 +65,8 @@ object AgoraConfig {
   lazy val configurationsRoute = config.as[Option[String]]("configurations.route").getOrElse("configurations")
   lazy val configurationsUrl = baseUrl + configurationsRoute + "/"
   lazy val webserviceInterface = config.as[Option[String]]("webservice.interface").getOrElse("0.0.0.0")
+  lazy val supervisorLogging = config.as[Option[Boolean]]("supervisor.logging").getOrElse(true)
+  lazy val kamonInstrumentation = config.as[Option[Boolean]]("kamon.instrumentation").getOrElse(true)
 
   // Mongo
   lazy val mongoDbHost = config.as[Option[String]]("mongodb.host").getOrElse("localhost")

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/exceptions/AgoraException.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/exceptions/AgoraException.scala
@@ -7,6 +7,7 @@ case class AgoraException(message: String = null,
                           cause: Throwable = null,
                           statusCode: StatusCode = StatusCodes.InternalServerError)
   extends Exception(message, cause) with LazyLogging {
-  logger.error(s"Cause: $cause")
-  logger.error(s"Message: $message")
+  override def getMessage: String = {
+    s"Cause: $cause" + " Message: $message"
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/PerRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/PerRequest.scala
@@ -4,6 +4,7 @@ package org.broadinstitute.dsde.agora.server.webservice
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor.{OneForOneStrategy, _}
 import cromwell.parser.WdlParser.SyntaxError
+import org.broadinstitute.dsde.agora.server.AgoraConfig
 import org.broadinstitute.dsde.agora.server.exceptions._
 import org.broadinstitute.dsde.agora.server.webservice.PerRequest._
 import spray.http.HttpHeader
@@ -59,8 +60,7 @@ trait PerRequest extends Actor {
   }
 
   override val supervisorStrategy =
-    OneForOneStrategy() {
-
+    OneForOneStrategy(loggingEnabled = AgoraConfig.supervisorLogging) {
       //Should make a single Authorization Exception trait to minimize code duplication.
       case e: AgoraEntityAuthorizationException =>
         r.complete(Unauthorized, AgoraException(e.getMessage, e.getCause, Unauthorized))

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraUnitTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraUnitTestSuite.scala
@@ -26,7 +26,8 @@ class AgoraUnitTestSuite extends Suites(
   new EntityPermissionsClientSpec,
   new NamespacePermissionsClientSpec) with BeforeAndAfterAll {
 
-  val agora = new Agora()     // Unit Tests use the local environment settings
+  val agora = new Agora()
+  // Unit Tests use the local environment settings
   val agoraBusiness = new AgoraBusiness()
   val timeout = 10.seconds
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/ApiServiceSpec.scala
@@ -52,7 +52,6 @@ class ApiServiceSpec extends FlatSpec with Directives with ScalatestRouteTest wi
     testEntityTaskWcWithId = agoraBusiness.find(testEntityTaskWc, None, Seq(testEntityTaskWc.entityType.get), mockAutheticatedOwner.get).head
     testConfigurationEntityWithId = agoraBusiness.find(testAgoraConfigurationEntity, None, Seq(testAgoraConfigurationEntity.entityType.get), mockAutheticatedOwner.get).head
     testEntityToBeRedactedWithId = agoraBusiness.find(testEntityToBeRedacted, None, Seq(testEntityToBeRedacted.entityType.get), mockAutheticatedOwner.get).headOption
-
   }
 
   val methodsService = new MethodsService() with ActorRefFactoryContext


### PR DESCRIPTION
Configurable with supervisor.logging which is true by default.
Also set whether or not to instrument Agora on application creation (could be in the config if we want to move it later)