### PR TITLE
Require that configs reference workflows (not tasks)

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -26,6 +26,8 @@ object AgoraTestData {
   val synopsis3 = Option("This is a test configuration")
   val documentation1 = Option("This is the documentation")
   val documentation2 = Option("This is documentation for another method")
+  val taskNamespace2 = Option("taskNamespace2")
+  val taskName2 = Option("taskName2")
 
   val badNamespace = Option("    ")
   val badName = Option("   ")
@@ -244,6 +246,30 @@ object AgoraTestData {
                                       |  "namespace": "ns"
                                       |}""".stripMargin)
 
+  val badConfigPayloadReferencesTask = Option( s"""{
+                                      |  "methodRepoMethod": {
+                                      |    "methodNamespace": "${taskNamespace2.get}",
+                                      |    "methodName": "${taskName2.get}",
+                                      |    "methodVersion": 1
+                                      |  },
+                                      |  "name": "first",
+                                      |  "workspaceName": {
+                                      |    "namespace": "foo",
+                                      |    "name": "bar"
+                                      |  },
+                                      |  "outputs": {
+                                      |
+                                      |  },
+                                      |  "inputs": {
+                                      |    "p": "hi"
+                                      |  },
+                                      |  "rootEntityType": "sample",
+                                      |  "prerequisites": {
+                                      |
+                                      |  },
+                                      |  "namespace": "ns"
+                                      |}""".stripMargin)
+
   val payloadWithValidOfficialDockerImageInWdl = Option( """
                                     |task wc {
                                     |  Array[File]+ files
@@ -351,7 +377,7 @@ object AgoraTestData {
                                                                 |  }
                                                                 |}
                                                                 | """.stripMargin)
-  val testEntity1 = AgoraEntity(namespace = namespace1,
+  val testWorkflow1 = AgoraEntity(namespace = namespace1,
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -359,7 +385,7 @@ object AgoraTestData {
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 
-  val testEntity2 = AgoraEntity(namespace = namespace2,
+  val testWorkflow2 = AgoraEntity(namespace = namespace2,
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -367,7 +393,7 @@ object AgoraTestData {
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 
-  val testEntity3 = AgoraEntity(namespace = namespace1,
+  val testWorkflow3 = AgoraEntity(namespace = namespace1,
     name = name2,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -375,7 +401,7 @@ object AgoraTestData {
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 
-  val testEntity4 = AgoraEntity(namespace = namespace1,
+  val testWorkflow4 = AgoraEntity(namespace = namespace1,
     name = name2,
     synopsis = synopsis2,
     documentation = documentation1,
@@ -383,7 +409,7 @@ object AgoraTestData {
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 
-  val testEntity5 = AgoraEntity(namespace = namespace1,
+  val testWorkflow5 = AgoraEntity(namespace = namespace1,
     name = name2,
     synopsis = synopsis1,
     documentation = documentation2,
@@ -391,7 +417,7 @@ object AgoraTestData {
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 
-  val testEntity6 = AgoraEntity(namespace = namespace1,
+  val testWorkflow6 = AgoraEntity(namespace = namespace1,
     name = name2,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -399,7 +425,17 @@ object AgoraTestData {
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 
-  val testEntity7 = AgoraEntity(namespace = namespace1,
+  val testWorkflow7 = new AgoraEntity(
+    namespace = namespace3,
+    name = name1,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = owner1,
+    payload = payload1,
+    entityType = Option(AgoraEntityType.Workflow)
+  )
+
+  val testTask1 = AgoraEntity(namespace = namespace1,
     name = name2,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -407,7 +443,17 @@ object AgoraTestData {
     payload = payload2,
     entityType = Option(AgoraEntityType.Task))
 
-  val testEntityToBeRedacted = AgoraEntity(namespace = namespace1,
+  val testTask2 = new AgoraEntity(
+    namespace = taskNamespace2,
+    name = taskName2,
+    synopsis = synopsis1,
+    documentation = documentation1,
+    owner = mockAutheticatedOwner,
+    payload = payload2,
+    entityType = Option(AgoraEntityType.Task)
+  )
+
+  val testTaskToBeRedacted1 = AgoraEntity(namespace = namespace1,
     name = name3,
     synopsis = synopsis2,
     documentation = documentation1,
@@ -416,16 +462,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testEntityToBeRedacted2 = AgoraEntity(namespace = namespace3,
-    name = name3,
-    synopsis = synopsis2,
-    documentation = documentation1,
-    owner = owner1,
-    payload = payload2,
-    entityType = Option(AgoraEntityType.Task)
-  )
-
-  val testEntityToBeRedacted3 = AgoraEntity(namespace = namespace3,
+  val testTaskToBeRedacted2 = AgoraEntity(namespace = namespace3,
     name = name4,
     synopsis = synopsis2,
     documentation = documentation1,
@@ -434,7 +471,16 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testEntityWithPublicPermissions = AgoraEntity(namespace = namespace1,
+  val testWorkflowToBeRedacted = AgoraEntity(namespace = namespace3,
+    name = name3,
+    synopsis = synopsis2,
+    documentation = documentation1,
+    owner = owner1,
+    payload = payload1,
+    entityType = Option(AgoraEntityType.Workflow)
+  )
+
+  val testTaskWithPublicPermissions = AgoraEntity(namespace = namespace1,
     name = name4,
     synopsis = synopsis2,
     documentation = documentation1,
@@ -452,17 +498,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testAgoraEntity = new AgoraEntity(
-    namespace = namespace3,
-    name = name1,
-    synopsis = synopsis1,
-    documentation = documentation1,
-    owner = owner1,
-    payload = payload1,
-    entityType = Option(AgoraEntityType.Workflow)
-  )
-
-  val testBadAgoraEntity = new AgoraEntity(
+  val testBadAgoraTask = new AgoraEntity(
     namespace = namespace1,
     name = name1,
     synopsis = synopsis1,
@@ -472,7 +508,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testBadAgoraEntityInvalidWdlImportFormat = new AgoraEntity(
+  val testBadWorkflowInvalidWdlImportFormat = new AgoraEntity(
     namespace = namespace1,
     name = name1,
     synopsis = synopsis1,
@@ -482,7 +518,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Workflow)
   )
 
-  val testBadAgoraEntityNonExistentWdlImportFormat = new AgoraEntity(
+  val testBadWorkflowNonExistentWdlImportFormat = new AgoraEntity(
     namespace = namespace1,
     name = name1,
     synopsis = synopsis1,
@@ -492,7 +528,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Workflow)
   )
 
-  val testAgoraEntityWithInvalidOfficialDockerImageInWdl = new AgoraEntity(namespace = namespace1,
+  val testTaskWithInvalidOfficialDockerImageInWdl = new AgoraEntity(namespace = namespace1,
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -501,7 +537,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testEntityWorkflowWithExistentWdlImport = new AgoraEntity(
+  val testWorkflowWithExistentWdlImport = new AgoraEntity(
     namespace = namespace1,
     name = name1,
     synopsis = synopsis1,
@@ -511,7 +547,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Workflow)
   )
 
-  val testAgoraEntityNonExistent = new AgoraEntity(
+  val testNonExistentWorkflow = new AgoraEntity(
     namespace = namespace1,
     name = nameNonExistent,
     synopsis = synopsis1,
@@ -521,7 +557,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Workflow)
   )
 
-  val testAgoraConfigurationEntity = new AgoraEntity(
+  val testConfig1 = new AgoraEntity(
     namespace = namespace1,
     name = name1,
     synopsis = synopsis3,
@@ -531,7 +567,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Configuration)
   )
 
-  val testAgoraConfigurationEntity2 = new AgoraEntity(
+  val testConfig2 = new AgoraEntity(
     namespace = namespace3,
     name = name2,
     synopsis = synopsis3,
@@ -541,9 +577,11 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Configuration)
   )
 
-  val testAgoraConfigurationEntity3 = new AgoraEntity(
-    namespace = namespace2,
-    name = name1,
+  val config3Namespace = Option("config3Namespace")
+  val config3Name = Option("config3Name")
+  val testConfig3 = new AgoraEntity(
+    namespace = config3Namespace,
+    name = config3Name,
     synopsis = synopsis3,
     documentation = documentation1,
     owner = owner1,
@@ -551,7 +589,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Configuration)
   )
 
-  val testAgoraConfigurationToBeRedacted = new AgoraEntity(
+  val testConfigToBeRedacted = new AgoraEntity(
     namespace = namespace3,
     name = name3,
     synopsis = synopsis3,
@@ -561,7 +599,19 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Configuration)
   )
 
-  val testIntegrationEntity = AgoraEntity(namespace = Option("___test1"),
+  val testBadConfigNamespace = Option("badConfigNamespace")
+  val testBadConfigName = Option("badConfigName")
+  val testBadConfigReferencesTask = new AgoraEntity(
+    namespace = testBadConfigNamespace,
+    name = testBadConfigName,
+    synopsis = synopsis3,
+    documentation = documentation1,
+    owner = owner1,
+    payload = badConfigPayloadReferencesTask,
+    entityType = Option(AgoraEntityType.Configuration)
+  )
+
+  val testIntegrationWorkflow = AgoraEntity(namespace = Option("___test1"),
     name = Option("testWorkflow"),
     synopsis = synopsis1,
     documentation = documentation1,
@@ -569,7 +619,7 @@ object AgoraTestData {
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 
-  val testIntegrationEntity2 = AgoraEntity(namespace = Option("___test2"),
+  val testIntegrationWorkflow2 = AgoraEntity(namespace = Option("___test2"),
     name = Option("testWorkflow"),
     synopsis = synopsis1,
     documentation = documentation1,
@@ -577,7 +627,7 @@ object AgoraTestData {
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 
-  val testAgoraEntityWithValidOfficialDockerImageInWdl = new AgoraEntity(namespace = Option("___docker_test"),
+  val testTaskWithValidOfficialDockerImageInWdl = new AgoraEntity(namespace = Option("___docker_test"),
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -586,7 +636,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testAgoraEntityWithInvalidOfficialDockerRepoNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
+  val testTaskWithInvalidOfficialDockerRepoNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -595,7 +645,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testAgoraEntityWithInvalidOfficialDockerTagNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
+  val testTaskWithInvalidOfficialDockerTagNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -604,7 +654,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testAgoraEntityWithValidPersonalDockerInWdl = new AgoraEntity(namespace = Option("___docker_test"),
+  val testTaskWithValidPersonalDockerInWdl = new AgoraEntity(namespace = Option("___docker_test"),
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -613,7 +663,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testAgoraEntityWithInvalidPersonalDockerUserNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
+  val testTaskWithInvalidPersonalDockerUserNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -622,7 +672,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testAgoraEntityWithInvalidPersonalDockerRepoNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
+  val testTaskWithInvalidPersonalDockerRepoNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -631,7 +681,7 @@ object AgoraTestData {
     entityType = Option(AgoraEntityType.Task)
   )
 
-  val testAgoraEntityWithInvalidPersonalDockerTagNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
+  val testTaskWithInvalidPersonalDockerTagNameInWdl = new AgoraEntity(namespace = Option("___docker_test"),
     name = name1,
     synopsis = synopsis1,
     documentation = documentation1,
@@ -639,22 +689,4 @@ object AgoraTestData {
     payload = payloadWithInvalidPersonalDockerTagNameInWdl,
     entityType = Option(AgoraEntityType.Task)
   )
-
-  def populateDatabase(agoraBusiness: AgoraBusiness) = {
-    agoraBusiness.insert(testEntity1, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity2, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity3, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity4, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity5, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity6, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity7, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntityTaskWc, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testAgoraConfigurationEntity, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testAgoraConfigurationEntity2, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntityToBeRedacted, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntityToBeRedacted2, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntityToBeRedacted3, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testAgoraConfigurationToBeRedacted, mockAutheticatedOwner.get)
-  }
-
 }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessIntegrationSpec.scala
@@ -18,46 +18,46 @@ class AgoraBusinessIntegrationSpec extends FlatSpec with BeforeAndAfterAll with 
   }
 
   "Agora" should "be able to store a task configuration with a valid (extant) official docker image" in {
-    val entity = agoraBusiness.insert(testAgoraEntityWithValidOfficialDockerImageInWdl, mockAutheticatedOwner.get)
+    val entity = agoraBusiness.insert(testTaskWithValidOfficialDockerImageInWdl, mockAutheticatedOwner.get)
     assert(agoraBusiness.findSingle(entity, Seq(entity.entityType.get), mockAutheticatedOwner.get) === entity)
   }
 
   "Agora" should "be unable to store a task configuration with an invalid docker image (invalid/non-existent repo name)" in {
     val thrown = intercept[DockerImageNotFoundException] {
-      agoraBusiness.insert(testAgoraEntityWithInvalidOfficialDockerRepoNameInWdl, mockAutheticatedOwner.get)
+      agoraBusiness.insert(testTaskWithInvalidOfficialDockerRepoNameInWdl, mockAutheticatedOwner.get)
     }
     assert(thrown != null)
   }
 
   "Agora" should "be unable to store a task configuration with an invalid docker image (invalid/non-existent tag name)" in {
     val thrown = intercept[DockerImageNotFoundException] {
-      agoraBusiness.insert(testAgoraEntityWithInvalidOfficialDockerTagNameInWdl, mockAutheticatedOwner.get)
+      agoraBusiness.insert(testTaskWithInvalidOfficialDockerTagNameInWdl, mockAutheticatedOwner.get)
     }
     assert(thrown != null)
   }
 
   "Agora" should "be able to store a task configuration with a valid (extant) personal docker image" in {
-    val entity = agoraBusiness.insert(testAgoraEntityWithValidPersonalDockerInWdl, mockAutheticatedOwner.get)
+    val entity = agoraBusiness.insert(testTaskWithValidPersonalDockerInWdl, mockAutheticatedOwner.get)
     assert(agoraBusiness.findSingle(entity, Seq(entity.entityType.get), mockAutheticatedOwner.get) === entity)
   }
 
   "Agora" should "be unable to store a task configuration with an invalid personal docker image (invalid/non-existent user name)" in {
     val thrown = intercept[DockerImageNotFoundException] {
-      agoraBusiness.insert(testAgoraEntityWithInvalidPersonalDockerUserNameInWdl, mockAutheticatedOwner.get)
+      agoraBusiness.insert(testTaskWithInvalidPersonalDockerUserNameInWdl, mockAutheticatedOwner.get)
     }
     assert(thrown != null)
   }
 
   "Agora" should "be unable to store a task configuration with an invalid personal docker image (invalid/non-existent repo name)" in {
     val thrown = intercept[DockerImageNotFoundException] {
-      agoraBusiness.insert(testAgoraEntityWithInvalidPersonalDockerRepoNameInWdl, mockAutheticatedOwner.get)
+      agoraBusiness.insert(testTaskWithInvalidPersonalDockerRepoNameInWdl, mockAutheticatedOwner.get)
     }
     assert(thrown != null)
   }
 
   "Agora" should "be unable to store a task configuration with an invalid personal docker image (invalid/non-existent tag name)" in {
     val thrown = intercept[DockerImageNotFoundException] {
-      agoraBusiness.insert(testAgoraEntityWithInvalidPersonalDockerTagNameInWdl, mockAutheticatedOwner.get)
+      agoraBusiness.insert(testTaskWithInvalidPersonalDockerTagNameInWdl, mockAutheticatedOwner.get)
     }
     assert(thrown != null)
   }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
@@ -15,7 +15,7 @@ class AgoraBusinessTest extends FlatSpec with Matchers with BeforeAndAfterAll wi
 
   override protected def beforeAll() = {
     ensureDatabasesAreRunning()
-    agoraBusiness.insert(testEntityToBeRedacted3, mockAutheticatedOwner.get)
+    agoraBusiness.insert(testTaskToBeRedacted2, mockAutheticatedOwner.get)
   }
 
   override protected def afterAll() = {
@@ -37,7 +37,7 @@ class AgoraBusinessTest extends FlatSpec with Matchers with BeforeAndAfterAll wi
   }
 
   "Agora" should "not let users without permissions redact a method" in {
-    val testEntityToBeRedactedWithId3 = agoraBusiness.find(testEntityToBeRedacted3, None, Seq(testEntityToBeRedacted3.entityType.get), mockAutheticatedOwner.get).head
+    val testEntityToBeRedactedWithId3 = agoraBusiness.find(testTaskToBeRedacted2, None, Seq(testTaskToBeRedacted2.entityType.get), mockAutheticatedOwner.get).head
     intercept[NamespaceAuthorizationException] {
       val rowsEdited: Int = agoraBusiness.delete(testEntityToBeRedactedWithId3, AgoraEntityType.MethodTypes, owner2.get)
     }
@@ -45,7 +45,7 @@ class AgoraBusinessTest extends FlatSpec with Matchers with BeforeAndAfterAll wi
 
   "Agora" should "allow admin users to redact any method" in {
     addAdminUser()
-    val testEntityToBeRedactedWithId3 = agoraBusiness.find(testEntityToBeRedacted3, None, Seq(testEntityToBeRedacted3.entityType.get), mockAutheticatedOwner.get).head
+    val testEntityToBeRedactedWithId3 = agoraBusiness.find(testTaskToBeRedacted2, None, Seq(testTaskToBeRedacted2.entityType.get), mockAutheticatedOwner.get).head
     val rowsEdited: Int = agoraBusiness.delete(testEntityToBeRedactedWithId3, AgoraEntityType.MethodTypes, adminUser.get)
     assert(rowsEdited === 1)
   }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/MethodsDbTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/MethodsDbTest.scala
@@ -21,7 +21,7 @@ class MethodsDbTest extends FlatSpec with BeforeAndAfterAll with AgoraTestFixtur
   }
 
   "Agora" should "be able to store a method" in {
-    val entityWithId = agoraDao.insert(testEntity1)
+    val entityWithId = agoraDao.insert(testWorkflow1)
 
     val entity = agoraDao.findSingle(entityWithId)
 
@@ -29,7 +29,7 @@ class MethodsDbTest extends FlatSpec with BeforeAndAfterAll with AgoraTestFixtur
   }
 
   "Agora" should "be able to query by namespace, name and snapshot id (version) and get back a single entity" in {
-    val entityWithId = agoraDao.insert(testEntity1)
+    val entityWithId = agoraDao.insert(testWorkflow1)
     val queryEntity = new AgoraEntity(namespace = namespace1, name = name1, snapshotId = entityWithId.snapshotId, entityType = Option(AgoraEntityType.Workflow))
 
     val entity = agoraDao.findSingle(queryEntity)
@@ -38,8 +38,8 @@ class MethodsDbTest extends FlatSpec with BeforeAndAfterAll with AgoraTestFixtur
   }
 
   "Agora" should "increment the snapshot id number if we insert the same namespace/name entity" in {
-    val entityWithId = agoraDao.insert(testEntity1)
-    val entityWithId2 = agoraDao.insert(testEntity1)
+    val entityWithId = agoraDao.insert(testWorkflow1)
+    val entityWithId2 = agoraDao.insert(testWorkflow1)
 
     val previousVersionEntity = entityWithId.copy(snapshotId = entityWithId2.snapshotId.map(id => id - 1))
 
@@ -51,7 +51,7 @@ class MethodsDbTest extends FlatSpec with BeforeAndAfterAll with AgoraTestFixtur
 
   "Agora" should "not find an entity if it doesn't exist" in {
     val thrown = intercept[AgoraEntityNotFoundException] {
-      agoraDao.findSingle(testAgoraEntityNonExistent)
+      agoraDao.findSingle(testNonExistentWorkflow)
     }
     assert(thrown != null)
   }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/EntityPermissionsClientSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/EntityPermissionsClientSpec.scala
@@ -24,15 +24,15 @@ class EntityPermissionsClientSpec extends FlatSpec with ScalaFutures with Before
     ensureDatabasesAreRunning()
     agoraBusiness = new AgoraBusiness()
     permissionBusiness = new PermissionBusiness()
-    agoraBusiness.insert(testEntity1, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity2, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntityWithPublicPermissions, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity3, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity4, mockAutheticatedOwner.get)
-    testEntityWithPublicPermissionsWithId = agoraBusiness.find(testEntityWithPublicPermissions, None, Seq(testEntityWithPublicPermissions.entityType.get), mockAutheticatedOwner.get).head;
-    foundTestEntity1 = agoraBusiness.find(testEntity1, None, Seq(testEntity1.entityType.get), mockAutheticatedOwner.get).head
-    foundTestEntity2 = agoraBusiness.find(testEntity2, None, Seq(testEntity2.entityType.get), mockAutheticatedOwner.get).head
-    testBatchPermissionEntity = agoraBusiness.find(testEntity4, None, Seq(testEntity3.entityType.get), mockAutheticatedOwner.get).head
+    agoraBusiness.insert(testWorkflow1, mockAutheticatedOwner.get)
+    agoraBusiness.insert(testWorkflow2, mockAutheticatedOwner.get)
+    agoraBusiness.insert(testTaskWithPublicPermissions, mockAutheticatedOwner.get)
+    agoraBusiness.insert(testWorkflow3, mockAutheticatedOwner.get)
+    agoraBusiness.insert(testWorkflow4, mockAutheticatedOwner.get)
+    testEntityWithPublicPermissionsWithId = agoraBusiness.find(testTaskWithPublicPermissions, None, Seq(testTaskWithPublicPermissions.entityType.get), mockAutheticatedOwner.get).head;
+    foundTestEntity1 = agoraBusiness.find(testWorkflow1, None, Seq(testWorkflow1.entityType.get), mockAutheticatedOwner.get).head
+    foundTestEntity2 = agoraBusiness.find(testWorkflow2, None, Seq(testWorkflow2.entityType.get), mockAutheticatedOwner.get).head
+    testBatchPermissionEntity = agoraBusiness.find(testWorkflow4, None, Seq(testWorkflow3.entityType.get), mockAutheticatedOwner.get).head
   }
 
   override def afterAll() = {
@@ -112,7 +112,7 @@ class EntityPermissionsClientSpec extends FlatSpec with ScalaFutures with Before
   }
 
   "Agora" should "allow public methods to be accessible" in {
-    agoraBusiness.findSingle(testEntityWithPublicPermissionsWithId, Seq(testEntityWithPublicPermissions.entityType.get), owner2.get)
+    agoraBusiness.findSingle(testEntityWithPublicPermissionsWithId, Seq(testTaskWithPublicPermissions.entityType.get), owner2.get)
     assert(1 === 1) //test passes as long as findSingle does not throw permissions error
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/NamespacePermissionsClientSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/NamespacePermissionsClientSpec.scala
@@ -21,10 +21,10 @@ class NamespacePermissionsClientSpec extends FlatSpec with ScalaFutures with Bef
     ensureDatabasesAreRunning()
     agoraBusiness = new AgoraBusiness()
     permissionBusiness = new PermissionBusiness()
-    agoraBusiness.insert(testEntity1, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity2, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntity3, mockAutheticatedOwner.get)
-    testBatchPermissionEntityWithId = agoraBusiness.find(testEntity3, None, Seq(testEntity3.entityType.get), mockAutheticatedOwner.get).head
+    agoraBusiness.insert(testWorkflow1, mockAutheticatedOwner.get)
+    agoraBusiness.insert(testWorkflow2, mockAutheticatedOwner.get)
+    agoraBusiness.insert(testWorkflow3, mockAutheticatedOwner.get)
+    testBatchPermissionEntityWithId = agoraBusiness.find(testWorkflow3, None, Seq(testWorkflow3.entityType.get), mockAutheticatedOwner.get).head
   }
 
   override def afterAll() = {
@@ -32,18 +32,18 @@ class NamespacePermissionsClientSpec extends FlatSpec with ScalaFutures with Bef
   }
 
   "Agora" should "add namespace permissions." in {
-    val insertCount1 = insertNamespacePermission(testEntity1, AccessControl(testEntity1.owner.get, AgoraPermissions(All)))
-    val insertCount2 = insertNamespacePermission(testEntity2, AccessControl(testEntity2.owner.get, AgoraPermissions(All)))
+    val insertCount1 = insertNamespacePermission(testWorkflow1, AccessControl(testWorkflow1.owner.get, AgoraPermissions(All)))
+    val insertCount2 = insertNamespacePermission(testWorkflow2, AccessControl(testWorkflow2.owner.get, AgoraPermissions(All)))
     assert(insertCount1 === 1)
     assert(insertCount2 === 1)
   }
 
   "Agora" should "should silently add a user to the db if not already there." in {
-    insertNamespacePermission(testEntity1, AccessControl(owner3.get, AgoraPermissions(All)))
+    insertNamespacePermission(testWorkflow1, AccessControl(owner3.get, AgoraPermissions(All)))
   }
 
   "Agora" should "return namespace permissions for authorized users." in {
-    val permissions = getNamespacePermission(testEntity1, testEntity1.owner.get)
+    val permissions = getNamespacePermission(testWorkflow1, testWorkflow1.owner.get)
     assert(permissions.canManage)
     assert(permissions.canCreate)
     assert(permissions.canRead)
@@ -52,8 +52,8 @@ class NamespacePermissionsClientSpec extends FlatSpec with ScalaFutures with Bef
   }
 
   "Agora" should "allow creation of namespaces that do not exist" in {
-    val testEntityNewNamespace = testEntity1.copy(namespace = Option("unused_namepace2"))
-    val permissions = getNamespacePermission(testEntityNewNamespace, testEntity2.owner.get)
+    val testEntityNewNamespace = testWorkflow1.copy(namespace = Option("unused_namepace2"))
+    val permissions = getNamespacePermission(testEntityNewNamespace, testWorkflow2.owner.get)
     assert(permissions.canCreate)
     assert(!permissions.canManage)
     assert(!permissions.canRead)
@@ -62,7 +62,7 @@ class NamespacePermissionsClientSpec extends FlatSpec with ScalaFutures with Bef
   }
 
   "Agora" should "give no permissions when namespace exists and user is unauthorized" in {
-    val permissions = getNamespacePermission(testEntity2, testEntity1.owner.get)
+    val permissions = getNamespacePermission(testWorkflow2, testWorkflow1.owner.get)
     assert(!permissions.canCreate)
     assert(!permissions.canManage)
     assert(!permissions.canRead)
@@ -71,10 +71,10 @@ class NamespacePermissionsClientSpec extends FlatSpec with ScalaFutures with Bef
   }
 
   "Agora" should "edit namespace permissions" in {
-    val editCount = editNamespacePermission(testEntity2, AccessControl(testEntity2.owner.get, AgoraPermissions(Redact)))
+    val editCount = editNamespacePermission(testWorkflow2, AccessControl(testWorkflow2.owner.get, AgoraPermissions(Redact)))
     assert(editCount == 1)
 
-    val permissions = getNamespacePermission(testEntity2, testEntity2.owner.get)
+    val permissions = getNamespacePermission(testWorkflow2, testWorkflow2.owner.get)
     assert(permissions.canRedact)
     assert(!permissions.canManage)
     assert(!permissions.canCreate)
@@ -83,7 +83,7 @@ class NamespacePermissionsClientSpec extends FlatSpec with ScalaFutures with Bef
   }
 
   "Agora" should "delete namespace permissions" in {
-    val deleteCount = deleteNamespacePermission(testEntity2, testEntity2.owner.get)
+    val deleteCount = deleteNamespacePermission(testWorkflow2, testWorkflow2.owner.get)
     assert(deleteCount == 1)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraImportIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraImportIntegrationSpec.scala
@@ -43,15 +43,15 @@ class AgoraImportIntegrationSpec extends FlatSpec with RouteTest with ScalatestR
   }
 
   "MethodsService" should "return a 201 when posting a WDL with a valid (extant) official docker image" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testAgoraEntityWithValidOfficialDockerImageInWdl) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testTaskWithValidOfficialDockerImageInWdl) ~>
       methodsService.postRoute ~> check {
       handleError(entity.as[AgoraEntity], (entity: AgoraEntity) => {
-        assert(entity.namespace === testAgoraEntityWithValidOfficialDockerImageInWdl.namespace)
-        assert(entity.name === testAgoraEntityWithValidOfficialDockerImageInWdl.name)
-        assert(entity.synopsis === testAgoraEntityWithValidOfficialDockerImageInWdl.synopsis)
-        assert(entity.documentation === testAgoraEntityWithValidOfficialDockerImageInWdl.documentation)
-        assert(entity.owner === testAgoraEntityWithValidOfficialDockerImageInWdl.owner)
-        assert(entity.payload === testAgoraEntityWithValidOfficialDockerImageInWdl.payload)
+        assert(entity.namespace === testTaskWithValidOfficialDockerImageInWdl.namespace)
+        assert(entity.name === testTaskWithValidOfficialDockerImageInWdl.name)
+        assert(entity.synopsis === testTaskWithValidOfficialDockerImageInWdl.synopsis)
+        assert(entity.documentation === testTaskWithValidOfficialDockerImageInWdl.documentation)
+        assert(entity.owner === testTaskWithValidOfficialDockerImageInWdl.owner)
+        assert(entity.payload === testTaskWithValidOfficialDockerImageInWdl.payload)
         assert(entity.snapshotId !== None)
         assert(entity.createDate !== None)
       })
@@ -60,7 +60,7 @@ class AgoraImportIntegrationSpec extends FlatSpec with RouteTest with ScalatestR
   }
 
   "MethodsService" should "return a 400 bad request when posting a WDL with an invalid official docker image (invalid/non-existent repo name)" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testAgoraEntityWithInvalidOfficialDockerRepoNameInWdl) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testTaskWithInvalidOfficialDockerRepoNameInWdl) ~>
       methodsService.postRoute ~> check {
       assert(status === BadRequest)
       assert(responseAs[String] != null)
@@ -68,7 +68,7 @@ class AgoraImportIntegrationSpec extends FlatSpec with RouteTest with ScalatestR
   }
 
   "MethodsService" should "return a 400 bad request when posting a WDL with an invalid official docker image (invalid/non-existent tag name)" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testAgoraEntityWithInvalidOfficialDockerTagNameInWdl) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testTaskWithInvalidOfficialDockerTagNameInWdl) ~>
       methodsService.postRoute ~> check {
       assert(status === BadRequest)
       assert(responseAs[String] != null)
@@ -76,15 +76,15 @@ class AgoraImportIntegrationSpec extends FlatSpec with RouteTest with ScalatestR
   }
 
   "MethodsService" should "return a 201 when posting a WDL with a valid (extant) personal docker image" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testAgoraEntityWithValidPersonalDockerInWdl) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testTaskWithValidPersonalDockerInWdl) ~>
       methodsService.postRoute ~> check {
       handleError(entity.as[AgoraEntity], (entity: AgoraEntity) => {
-        assert(entity.namespace === testAgoraEntityWithValidPersonalDockerInWdl.namespace)
-        assert(entity.name === testAgoraEntityWithValidPersonalDockerInWdl.name)
-        assert(entity.synopsis === testAgoraEntityWithValidPersonalDockerInWdl.synopsis)
-        assert(entity.documentation === testAgoraEntityWithValidPersonalDockerInWdl.documentation)
-        assert(entity.owner === testAgoraEntityWithValidPersonalDockerInWdl.owner)
-        assert(entity.payload === testAgoraEntityWithValidPersonalDockerInWdl.payload)
+        assert(entity.namespace === testTaskWithValidPersonalDockerInWdl.namespace)
+        assert(entity.name === testTaskWithValidPersonalDockerInWdl.name)
+        assert(entity.synopsis === testTaskWithValidPersonalDockerInWdl.synopsis)
+        assert(entity.documentation === testTaskWithValidPersonalDockerInWdl.documentation)
+        assert(entity.owner === testTaskWithValidPersonalDockerInWdl.owner)
+        assert(entity.payload === testTaskWithValidPersonalDockerInWdl.payload)
         assert(entity.snapshotId !== None)
         assert(entity.createDate !== None)
       })
@@ -93,7 +93,7 @@ class AgoraImportIntegrationSpec extends FlatSpec with RouteTest with ScalatestR
   }
 
   "MethodsService" should "return a 400 bad request when posting a WDL with an invalid personal docker image (invalid/non-existent user name)" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testAgoraEntityWithInvalidPersonalDockerUserNameInWdl) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testTaskWithInvalidPersonalDockerUserNameInWdl) ~>
       methodsService.postRoute ~> check {
       assert(status === BadRequest)
       assert(responseAs[String] != null)
@@ -101,7 +101,7 @@ class AgoraImportIntegrationSpec extends FlatSpec with RouteTest with ScalatestR
   }
 
   "MethodsService" should "return a 400 bad request when posting a WDL with an invalid personal docker image (invalid/non-existent repo name)" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testAgoraEntityWithInvalidPersonalDockerRepoNameInWdl) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testTaskWithInvalidPersonalDockerRepoNameInWdl) ~>
       methodsService.postRoute ~> check {
       assert(status === BadRequest)
       assert(responseAs[String] != null)
@@ -109,7 +109,7 @@ class AgoraImportIntegrationSpec extends FlatSpec with RouteTest with ScalatestR
   }
 
   "MethodsService" should "return a 400 bad request when posting a WDL with an invalid personal docker image (invalid/non-existent tag name)" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testAgoraEntityWithInvalidPersonalDockerTagNameInWdl) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testTaskWithInvalidPersonalDockerTagNameInWdl) ~>
       methodsService.postRoute ~> check {
       assert(status === BadRequest)
       assert(responseAs[String] != null)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraImportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraImportSpec.scala
@@ -21,7 +21,7 @@ class AgoraImportSpec extends ApiServiceSpec {
   override def beforeAll() = {
     ensureDatabasesAreRunning()
     testEntityTaskWcWithId = agoraBusiness.insert(testEntityTaskWc, mockAutheticatedOwner.get)
-    agoraBusiness.insert(testEntityWorkflowWithExistentWdlImport, mockAutheticatedOwner.get)
+    agoraBusiness.insert(testWorkflowWithExistentWdlImport, mockAutheticatedOwner.get)
   }
 
   override def afterAll() = {
@@ -29,7 +29,7 @@ class AgoraImportSpec extends ApiServiceSpec {
   }
 
   "MethodsService" should "return a 400 bad request when posting a WDL with an invalid import statement" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testBadAgoraEntityInvalidWdlImportFormat) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testBadWorkflowInvalidWdlImportFormat) ~>
       methodsService.postRoute ~> check {
       assert(status === BadRequest)
       assert(responseAs[String] != null)
@@ -37,7 +37,7 @@ class AgoraImportSpec extends ApiServiceSpec {
   }
 
   "MethodsService" should "return a 404 bad request when posting a WDL with an import statement that references a non-existent method" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testBadAgoraEntityNonExistentWdlImportFormat) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testBadWorkflowNonExistentWdlImportFormat) ~>
       methodsService.postRoute ~> check {
       assert(status === NotFound)
       assert(responseAs[String] != null)
@@ -51,7 +51,7 @@ class AgoraImportSpec extends ApiServiceSpec {
       handleError(entity.as[AgoraEntity], (entity: AgoraEntity) => assert(brief(entity) === brief(testEntityTaskWcWithId)))
       assert(status === OK)
     }
-    Post(ApiUtil.Methods.withLeadingVersion, testEntityWorkflowWithExistentWdlImport) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testWorkflowWithExistentWdlImport) ~>
       methodsService.postRoute ~> check {
       handleError(entity.as[AgoraEntity], (entity: AgoraEntity) => {
         assert(entity.namespace === namespace1)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraMethodsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraMethodsSpec.scala
@@ -27,14 +27,14 @@ class AgoraMethodsSpec extends ApiServiceSpec {
 
   override def beforeAll() = {
     ensureDatabasesAreRunning()
-    testEntity1WithId = agoraBusiness.insert(testEntity1, mockAutheticatedOwner.get)
-    testEntity2WithId = agoraBusiness.insert(testEntity2, mockAutheticatedOwner.get)
-    testEntity3WithId = agoraBusiness.insert(testEntity3, mockAutheticatedOwner.get)
-    testEntity4WithId = agoraBusiness.insert(testEntity4, mockAutheticatedOwner.get)
-    testEntity5WithId = agoraBusiness.insert(testEntity5, mockAutheticatedOwner.get)
-    testEntity6WithId = agoraBusiness.insert(testEntity6, mockAutheticatedOwner.get)
-    testEntity7WithId = agoraBusiness.insert(testEntity7, mockAutheticatedOwner.get)
-    testEntityToBeRedactedWithId = agoraBusiness.insert(testEntityToBeRedacted, mockAutheticatedOwner.get)
+    testEntity1WithId = agoraBusiness.insert(testWorkflow1, mockAutheticatedOwner.get)
+    testEntity2WithId = agoraBusiness.insert(testWorkflow2, mockAutheticatedOwner.get)
+    testEntity3WithId = agoraBusiness.insert(testWorkflow3, mockAutheticatedOwner.get)
+    testEntity4WithId = agoraBusiness.insert(testWorkflow4, mockAutheticatedOwner.get)
+    testEntity5WithId = agoraBusiness.insert(testWorkflow5, mockAutheticatedOwner.get)
+    testEntity6WithId = agoraBusiness.insert(testWorkflow6, mockAutheticatedOwner.get)
+    testEntity7WithId = agoraBusiness.insert(testTask1, mockAutheticatedOwner.get)
+    testEntityToBeRedactedWithId = agoraBusiness.insert(testTaskToBeRedacted1, mockAutheticatedOwner.get)
   }
 
   override def afterAll() = {
@@ -105,7 +105,7 @@ class AgoraMethodsSpec extends ApiServiceSpec {
   }
 
   "Agora" should "create a method and return with a status of 201" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testAgoraEntity) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testWorkflow7) ~>
       methodsService.postRoute ~> check {
       handleError(entity.as[AgoraEntity], (entity: AgoraEntity) => {
         assert(entity.namespace === namespace3)
@@ -122,7 +122,7 @@ class AgoraMethodsSpec extends ApiServiceSpec {
   }
 
   "Agora" should "return a 400 bad request when posting a malformed payload" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testBadAgoraEntity) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testBadAgoraTask) ~>
       methodsService.postRoute ~> check {
       assert(status === BadRequest)
       assert(responseAs[String] != null)
@@ -174,7 +174,7 @@ class AgoraMethodsSpec extends ApiServiceSpec {
   }
 
   "Agora" should "not allow you to post a new configuration to the methods route" in {
-    Post(ApiUtil.Methods.withLeadingVersion, testAgoraConfigurationEntity) ~>
+    Post(ApiUtil.Methods.withLeadingVersion, testConfig1) ~>
       methodsService.postRoute ~> check {
       rejection === ValidationRejection
     }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraProjectionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraProjectionsSpec.scala
@@ -24,14 +24,14 @@ class AgoraProjectionsSpec extends ApiServiceSpec {
 
   override def beforeAll() = {
     ensureDatabasesAreRunning()
-    testEntity1WithId = agoraBusiness.insert(testEntity1, mockAutheticatedOwner.get)
-    testEntity2WithId = agoraBusiness.insert(testEntity2, mockAutheticatedOwner.get)
-    testEntity3WithId = agoraBusiness.insert(testEntity3, mockAutheticatedOwner.get)
-    testEntity4WithId = agoraBusiness.insert(testEntity4, mockAutheticatedOwner.get)
-    testEntity5WithId = agoraBusiness.insert(testEntity5, mockAutheticatedOwner.get)
-    testEntity6WithId = agoraBusiness.insert(testEntity6, mockAutheticatedOwner.get)
-    testEntity7WithId = agoraBusiness.insert(testEntity7, mockAutheticatedOwner.get)
-    testEntityToBeRedactedWithId = agoraBusiness.insert(testEntityToBeRedacted, mockAutheticatedOwner.get)
+    testEntity1WithId = agoraBusiness.insert(testWorkflow1, mockAutheticatedOwner.get)
+    testEntity2WithId = agoraBusiness.insert(testWorkflow2, mockAutheticatedOwner.get)
+    testEntity3WithId = agoraBusiness.insert(testWorkflow3, mockAutheticatedOwner.get)
+    testEntity4WithId = agoraBusiness.insert(testWorkflow4, mockAutheticatedOwner.get)
+    testEntity5WithId = agoraBusiness.insert(testWorkflow5, mockAutheticatedOwner.get)
+    testEntity6WithId = agoraBusiness.insert(testWorkflow6, mockAutheticatedOwner.get)
+    testEntity7WithId = agoraBusiness.insert(testTask1, mockAutheticatedOwner.get)
+    testEntityToBeRedactedWithId = agoraBusiness.insert(testTaskToBeRedacted1, mockAutheticatedOwner.get)
   }
 
   override def afterAll() = {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -28,8 +28,8 @@ class PermissionIntegrationSpec extends FlatSpec with RouteTest with ScalatestRo
 
   override def beforeAll(): Unit = {
     ensureDatabasesAreRunning()
-    agoraEntity1 = agoraBusiness.insert(testIntegrationEntity, mockAutheticatedOwner.get)
-    agoraEntity2 = agoraBusiness.insert(testIntegrationEntity2, owner2.get)
+    agoraEntity1 = agoraBusiness.insert(testIntegrationWorkflow, mockAutheticatedOwner.get)
+    agoraEntity2 = agoraBusiness.insert(testIntegrationWorkflow2, owner2.get)
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
We want to disallow inserting a configuration that references a task -- it must reference a workflow.

The only real changes are in AgoraBusiness. (Also added a test in AgoraConfigurationsSpec -- the rest of the changes are due to renaming test entities).
