### PR TITLE
Fix build error due to conflicting versions of guava library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
   "com.gettyimages" %% "spray-swagger" % "0.5.0",
   "com.github.simplyscala" %% "scalatest-embedmongo" % "0.2.2",
   "com.google.api-client" % "google-api-client" % "1.20.0" excludeAll ExclusionRule(organization = "com.google.guava"),
-  "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev53-1.20.0",
+  "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev53-1.20.0" excludeAll ExclusionRule(organization = "com.google.guava"),
   "com.h2database" % "h2" % "1.3.175",
   "com.typesafe.akka" %% "akka-actor" % "2.3.4",
   "com.typesafe.akka" %% "akka-slf4j" % "2.3.11",


### PR DESCRIPTION
The Agora build was broken because we were pulling in conflicting versions of the guava library (required by Google libraries through their chains of dependencies).

This wasn't happening before but some of those libraries must have changed to produce the conflict.

Fixed by adding a rule to build.sbt.
