### PR TITLE
Standardize how we docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,16 @@
 # Production build/deploy/start of DSDE Methods Repository Webservice
 
-# Basis image- Lukas K. recommended
-FROM debian:jessie
-MAINTAINER DSDE <dsde-engineering@broadinstitute.org>
+# http://github.com/broadinstitute/scala-baseimage
+FROM broadinstitute/scala-baseimage
 
-
-# Install necessary packages including java 8 jre and sbt and clean up apt caches
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && \
-    echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections
-
-RUN apt-get update && \
-    apt-get --no-install-recommends install -y --force-yes oracle-java8-installer &&\
-    apt-get clean autoclean && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/{apt,dpkg,cache,log}/ /var/cache/oracle-jdk8-installer 
-
-# Expose the port used by the webservice
+# Expose the port used by Agora webservice
 EXPOSE 8000
 
-WORKDIR /usr/agora
+# Install Agora
+ADD . /agora
+RUN ["/bin/bash", "-c", "/agora/docker/install.sh /agora"]
 
-COPY agora-0.1-SNAPSHOT.jar /usr/agora/
-
-# Start the webservice with default parameters do not use default config
-ENTRYPOINT ["java", "-Djava.library.path=./native", "-Dconfig.file=/etc/agora.conf", "-javaagent:agora-0.1-SNAPSHOT.jar", "-jar", "agora-0.1-SNAPSHOT.jar"]
+# Add Agora as a service (it will start when the container starts)
+RUN mkdir /etc/service/agora && \
+    mkdir /var/log/agora && \
+    cp /agora/docker/run.sh /etc/service/agora/run

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+AGORA_DIR=$1
+cd $AGORA_DIR
+sbt assembly
+AGORA_JAR=$(find target | grep 'agora.*\.jar')
+mv $AGORA_JAR ./agora.jar
+sbt clean

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -e
+java $JAVA_OPTS -Djava.library.path=./native -Dconfig.file=/etc/agora.conf -javaagent:/agora/agora.jar -jar /agora/agora.jar


### PR DESCRIPTION
This brings Agora in line with how the rest of the teams handle dockerizing. It also allows us to pass in some options to java when we start Agora (some certs need to be passed in to support talking to mysql via ssl).
