### PR TITLE
Use least powerful scope needed to query admin group

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/GoogleApiUtils.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/GoogleApiUtils.scala
@@ -17,7 +17,7 @@ object GoogleApiUtils {
   val emailAddress = AgoraConfig.gcsServiceAccountEmail
   val JSON_FACTORY = JacksonFactory.getDefaultInstance
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
-  val directoryScopes = Collections.singleton(DirectoryScopes.ADMIN_DIRECTORY_GROUP)
+  val directoryScopes = Collections.singleton(DirectoryScopes.ADMIN_DIRECTORY_GROUP_MEMBER_READONLY)
 
   private def getGroupServiceAccountCredential: Credential = {
     new GoogleCredential.Builder()


### PR DESCRIPTION
We only need the member read only scope. We were using a broader scope providing read/write access to the group.
