### PR TITLE
swagger tweaks

### DIFF
--- a/src/main/resources/swagger/agora.yaml
+++ b/src/main/resources/swagger/agora.yaml
@@ -1587,7 +1587,6 @@ definitions:
         type: string
         description: URL where resource can be accessed.
       payloadObject:
-        type: object
         $ref: '#/definitions/ConfigurationPayload'
       entityType:
         type: string
@@ -1692,48 +1691,52 @@ definitions:
         items:
           $ref: '#/definitions/AccessControl'
   ConfigurationPayload:
-    name:
-      type: string
-      description: Name of this config
-      default: cancer_exome_pipeline_v2
-    namespace:
-      type: string
-      description: Namespace of this config
-      default: broad-dsde-dev
-    methodRepoMethod:
-      methodName:
+    type: object
+    properties:
+      name:
         type: string
-        description: Name of referenced method
+        description: Name of this config
         default: cancer_exome_pipeline_v2
-      methodNamespace:
+      namespace:
         type: string
-        description: Namespace of referenced method
-        default: broad-dsde-dev,
-      methodVersion:
+        description: Namespace of this config
+        default: broad-dsde-dev
+      methodRepoMethod:
+        type: object
+        properties:
+          methodName:
+            type: string
+            description: Name of referenced method
+            default: cancer_exome_pipeline_v2
+          methodNamespace:
+            type: string
+            description: Namespace of referenced method
+            default: broad-dsde-dev,
+          methodVersion:
+            type: integer
+            description: Snapshot ID of referenced method
+            default: 1
+      outputs:
+        type: object
+        description: Map[String, AttributeString] from method's WDL outputs to fields in the workspace data model
+      inputs:
+        type: object
+        description: Map[String, AttributeString] from method's WDL inputs to fields in the workspace data model
+      rootEntityType:
+        type: string
+        default: pair
+      prerequisites:
+        type: object
+        description: Map[String, AttributeString]
+        default: {}
+      methodConfigVersion:
         type: integer
-        description: Snapshot ID of referenced method
+        description: Snapshot ID of this config
         default: 1
-    outputs:
-      type: object
-      description: Map[String, AttributeString] from method's WDL outputs to fields in the workspace data model
-    inputs:
-      type: object
-      description: Map[String, AttributeString] from method's WDL inputs to fields in the workspace data model
-    rootEntityType:
-      type: string
-      default: pair
-    prerequisites:
-      type: object
-      description: Map[String, AttributeString]
-      default: {}
-    methodConfigVersion:
-      type: integer
-      description: Snapshot ID of this config
-      default: 1
-    deleted:
-      type: boolean
-      description: Has this config been deleted?
-      default: false
+      deleted:
+        type: boolean
+        description: Has this config been deleted?
+        default: false
   BadRequest:
     type: object
     properties:


### PR DESCRIPTION
view this PR with `?w=1` in the url to ignore whitespace changes; it's much cleaner.

adds/removes `type: object` in the right places to get `ConfigurationPayload` and `methodRepoMethod` to show up in the swagger ui.