### PR TITLE
GAWB-3052: Request completion refactoring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,9 @@ organization := "org.broadinstitute"
 
 scalaVersion := "2.12.4"
 
-// uncomment to see compile warnings
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature")
 
-lazy val akkaV = "2.5.9"
+lazy val akkaV = "2.5.11"
 lazy val akkaHttpV = "10.0.11"
 
 val cromwellVersion = "30-4de204a"
@@ -33,11 +32,13 @@ libraryDependencies ++= Seq(
   "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev53-1.20.0" excludeAll ExclusionRule(organization = "com.google.guava"),
   "com.h2database" % "h2" % "1.3.175",
   "com.typesafe.akka" %% "akka-actor" % akkaV,
+  // It was necessary to explicitly specify the version for akka-stream to appease Akka as it complains otherwise with:
+  // "Akka version MUST be the same across all modules of Akka that you are using."
   "com.typesafe.akka" %% "akka-stream" % akkaV,
   "com.typesafe.akka" %% "akka-http" % akkaHttpV,
   "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
   "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV,
-  "com.typesafe.akka" %% "akka-slf4j" % "2.5.9",
+  "com.typesafe.akka" %% "akka-slf4j" % akkaV,
   "com.typesafe" % "config" % "1.2.1",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.1",
   "com.typesafe.slick" %% "slick" % "3.2.0",

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/ServerInitializer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/ServerInitializer.scala
@@ -57,7 +57,7 @@ class ServerInitializer extends LazyLogging {
 
     val apiService = new ApiService(permsDataSource, healthMonitor)
 
-    Http().bindAndHandle(apiService.route, "0.0.0.0", 8000)
+    Http().bindAndHandle(apiService.route, AgoraConfig.webserviceInterface, AgoraConfig.port)
       .recover {
         case t: Throwable =>
           logger.error(s"Unable to bind to port ${AgoraConfig.port} on interface ${AgoraConfig.webserviceInterface}")
@@ -83,8 +83,8 @@ class ServerInitializer extends LazyLogging {
 
   private def stopAdminGroupPoller() = {
     Try(adminGroupPollerSchedule.cancel()) recover {
-      case e: NullPointerException => // Nothing to do; no scheduler was created at the first place
-      case t: Throwable => throw t
+      case _: NullPointerException => // Nothing to do; no scheduler was created at the first place
+      case t: Throwable => logger.warn(s"Unable to stop the admin group poller because '${t.getMessage}'")
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/SwaggerRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/SwaggerRoutes.scala
@@ -20,21 +20,21 @@ trait SwaggerRoutes {
           serveIndex()
       }
     } ~
-      path("agora.yaml") {
-        get {
-          getFromResource("swagger/agora.yaml")
-        }
-      } ~
-      // We have to be explicit about the paths here since we're matching at the root URL and we don't
-      // want to catch all paths lest we circumvent Spray's not-found and method-not-allowed error
-      // messages.
-      (pathSuffixTest("o2c.html") | pathSuffixTest("swagger-ui.js")
-        | pathPrefixTest("css") | pathPrefixTest("fonts") | pathPrefixTest("images")
-        | pathPrefixTest("lang") | pathPrefixTest("lib")) {
-        get {
-          getFromResourceDirectory(swaggerUiPath)
-        }
+    path("agora.yaml") {
+      get {
+        getFromResource("swagger/agora.yaml")
       }
+    } ~
+    // We have to be explicit about the paths here since we're matching at the root URL and we don't
+    // want to catch all paths lest we circumvent Spray's not-found and method-not-allowed error
+    // messages.
+    (pathSuffixTest("o2c.html") | pathSuffixTest("swagger-ui.js")
+      | pathPrefixTest("css") | pathPrefixTest("fonts") | pathPrefixTest("images")
+      | pathPrefixTest("lang") | pathPrefixTest("lib")) {
+      get {
+        getFromResourceDirectory(swaggerUiPath)
+      }
+    }
   }
 
   private def serveIndex(): server.Route = {

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
@@ -463,8 +463,45 @@ class AgoraBusiness(permissionsDataSource: PermissionsDataSource)(implicit ec: E
     findSingle(entity.namespace.get, entity.name.get, entity.snapshotId.get, entityTypes, username)
   }
 
+//  private def validateDockerImage(task: Task) = {
+//    // Per DSDEEPB-2525, in the interests of expediency, we are disabling docker image validation as we do not support validation of private docker images
+//    // When that functionality is added back in, then this is where it should go.
+//
+////    if (task.runtimeAttributes.docker.isDefined) {
+////      val dockerImageReference = parseDockerString(task.runtimeAttributes.docker.get)
+////      if (dockerImageReference.isDefined) {
+////        DockerHubClient.doesDockerImageExist(dockerImageReference.get)
+////      }
+////    }
+//    true
+//  }
+
   private def resolveMethodRef(payload: String): AgoraEntity = {
     val queryMethod = AgoraApiJsonSupport.methodRef(payload)
     AgoraDao.createAgoraDao(AgoraEntityType.MethodTypes).findSingle(queryMethod)
   }
+
+//  /**
+//   * Parses out user/image:tag from a docker string.
+//   *
+//   * @param imageId docker imageId string.  Looks like ubuntu:latest ggrant/joust:latest
+//   */
+//  private def parseDockerString(imageId: String) : Option[DockerImageReference] = {
+//    if (imageId.startsWith("gcr.io")) {
+//      None
+//    } else {
+//      val splitUser = imageId.split('/')
+//      if (splitUser.length > 2) {
+//        throw new SyntaxError("Docker image string '" + imageId + "' is malformed")
+//      }
+//      val user = if (splitUser.length == 1) None else Option(splitUser(0))
+//      val splitTag = splitUser(splitUser.length - 1).split(':')
+//      if (splitTag.length > 2) {
+//        throw new SyntaxError("Docker image string '" + imageId + "' is malformed")
+//      }
+//      val repo = splitTag(0)
+//      val tag = if (splitTag.length == 1) "latest" else splitTag(1)
+//      Option(DockerImageReference(user, repo, tag))
+//    }
+//  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
@@ -463,45 +463,8 @@ class AgoraBusiness(permissionsDataSource: PermissionsDataSource)(implicit ec: E
     findSingle(entity.namespace.get, entity.name.get, entity.snapshotId.get, entityTypes, username)
   }
 
-//  private def validateDockerImage(task: Task) = {
-//    // Per DSDEEPB-2525, in the interests of expediency, we are disabling docker image validation as we do not support validation of private docker images
-//    // When that functionality is added back in, then this is where it should go.
-//
-////    if (task.runtimeAttributes.docker.isDefined) {
-////      val dockerImageReference = parseDockerString(task.runtimeAttributes.docker.get)
-////      if (dockerImageReference.isDefined) {
-////        DockerHubClient.doesDockerImageExist(dockerImageReference.get)
-////      }
-////    }
-//    true
-//  }
-
   private def resolveMethodRef(payload: String): AgoraEntity = {
     val queryMethod = AgoraApiJsonSupport.methodRef(payload)
     AgoraDao.createAgoraDao(AgoraEntityType.MethodTypes).findSingle(queryMethod)
   }
-
-//  /**
-//   * Parses out user/image:tag from a docker string.
-//   *
-//   * @param imageId docker imageId string.  Looks like ubuntu:latest ggrant/joust:latest
-//   */
-//  private def parseDockerString(imageId: String) : Option[DockerImageReference] = {
-//    if (imageId.startsWith("gcr.io")) {
-//      None
-//    } else {
-//      val splitUser = imageId.split('/')
-//      if (splitUser.length > 2) {
-//        throw new SyntaxError("Docker image string '" + imageId + "' is malformed")
-//      }
-//      val user = if (splitUser.length == 1) None else Option(splitUser(0))
-//      val splitTag = splitUser(splitUser.length - 1).split(':')
-//      if (splitTag.length > 2) {
-//        throw new SyntaxError("Docker image string '" + imageId + "' is malformed")
-//      }
-//      val repo = splitTag(0)
-//      val tag = if (splitTag.length == 1) "latest" else splitTag(1)
-//      Option(DockerImageReference(user, repo, tag))
-//    }
-//  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/ga4gh/Ga4ghQueryHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/ga4gh/Ga4ghQueryHandler.scala
@@ -18,12 +18,8 @@ trait Ga4ghQueryHandler extends LazyLogging {
   // Include entity payloads in returned results
   val DefaultProjection = Some(AgoraEntityProjection(Seq[String]("payload", "synopsis"), Seq.empty[String]))
 
-  def queryPublicSingle(entity: AgoraEntity): Future[ToolVersion] = {
-    val entityTypes = Seq(entity.entityType.getOrElse(throw ValidationException("need an entity type")))
-    agoraBusiness.findSingle(entity, entityTypes, AccessControl.publicUser) map { foundEntity =>
-      ToolVersion(foundEntity)
-    }
-  }
+  def queryPublicSingle(entity: AgoraEntity): Future[ToolVersion] =
+    queryPublicSingleEntity(entity) map (ToolVersion(_))
 
   def queryPublicSingleEntity(entity: AgoraEntity): Future[AgoraEntity] = {
     val entityTypes = Seq(entity.entityType.getOrElse(throw ValidationException("need an entity type")))

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraService.scala
@@ -61,12 +61,7 @@ abstract class AgoraService(permissionsDataSource: PermissionsDataSource) extend
               }
             } ~
             delete {
-              val deletionAttempt = agoraBusiness.delete(targetEntity, entityTypes, username)
-
-              onComplete(deletionAttempt) {
-                case Success(rowsDeleted) => complete(rowsDeleted.toString)
-                case Failure(error) => failWith(error)
-              }
+              complete(agoraBusiness.delete(targetEntity, entityTypes, username).map(_.toString))
             } ~
             post {
               // only allow copying (post) for methods
@@ -79,12 +74,7 @@ abstract class AgoraService(permissionsDataSource: PermissionsDataSource) extend
                     case FailureZ(errors) => throw new IllegalArgumentException(s"Method is invalid: Errors: $errors")
                   }
                   parameters("redact".as[Boolean] ? false) { redact =>
-                    val copyingAttempt = agoraBusiness.copy(targetEntity, newEntity, redact, entityTypes, username)
-
-                    onComplete(copyingAttempt) {
-                      case Success(entities) => complete(entities)
-                      case Failure(error) => failWith(error)
-                    }
+                    complete(agoraBusiness.copy(targetEntity, newEntity, redact, entityTypes, username))
                   }
                 }
               }
@@ -95,24 +85,14 @@ abstract class AgoraService(permissionsDataSource: PermissionsDataSource) extend
   def queryMethodDefinitionsRoute =
     (versionedPath(PathMatcher("methods" / "definitions")) & get &
       authenticationDirectives.usernameFromRequest(())) { username =>
-        val listingAttempt = agoraBusiness.listDefinitions(username)
-
-        onComplete(listingAttempt) {
-          case Success(definitions) => complete(definitions)
-          case Failure(error) => failWith(error)
-        }
+        complete(agoraBusiness.listDefinitions(username))
     }
 
   // all configurations that reference any snapshot of the supplied method
   def queryAssociatedConfigurationsRoute =
     (versionedPath(PathMatcher("methods" / Segment / Segment / "configurations")) & get &
       authenticationDirectives.usernameFromRequest(())) { (namespace, name, username) =>
-        val listingAttempt = agoraBusiness.listAssociatedConfigurations(namespace, name, username)
-
-        onComplete(listingAttempt) {
-          case Success(configs) => complete(configs)
-          case Failure(error) => failWith(error)
-        }
+        complete(agoraBusiness.listAssociatedConfigurations(namespace, name, username))
     }
 
   // all configurations that have the same inputs and outputs of the supplied method snapshot,
@@ -120,12 +100,7 @@ abstract class AgoraService(permissionsDataSource: PermissionsDataSource) extend
   def queryCompatibleConfigurationsRoute =
     (versionedPath(PathMatcher("methods" / Segment / Segment / IntNumber / "configurations")) & get &
       authenticationDirectives.usernameFromRequest(())) { (namespace, name, snapshotId, username) =>
-        val listingAttempt = agoraBusiness.listCompatibleConfigurations(namespace, name, snapshotId, username)
-
-        onComplete(listingAttempt) {
-          case Success(configs) => complete(configs)
-          case Failure(error) => failWith(error)
-        }
+        complete(agoraBusiness.listCompatibleConfigurations(namespace, name, snapshotId, username))
     }
 
   // GET http://root.com/methods?
@@ -138,12 +113,7 @@ abstract class AgoraService(permissionsDataSource: PermissionsDataSource) extend
           val projection = projectionFromParams(params)
           val entityTypes = AgoraEntityType.byPath(path)
 
-          val queryAttempt = agoraBusiness.find(entity, projection, entityTypes, username)
-
-          onComplete(queryAttempt) {
-            case Success(entities) => complete(entities)
-            case Failure(error) => failWith(error)
-          }
+          complete(agoraBusiness.find(entity, projection, entityTypes, username))
         }
       }
     }
@@ -159,11 +129,7 @@ abstract class AgoraService(permissionsDataSource: PermissionsDataSource) extend
             case _ => agoraEntity
           }
 
-          val addAttempt = agoraBusiness.insert(entityWithType, username)
-          onComplete(addAttempt) {
-            case Success(entity) => complete(Created, entity)
-            case Failure(error) => failWith(error)
-          }
+          complete(Created, agoraBusiness.insert(entityWithType, username))
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/EntityPermissionsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/EntityPermissionsService.scala
@@ -47,7 +47,8 @@ class EntityPermissionsService(dataSource: PermissionsDataSource) extends RouteH
           } ~
           delete {
             val userToRemove = getUserFromParams(params)
-            complete(permissionBusiness.deleteEntityPermission(agoraEntity, username, userToRemove).map(_ => AccessControl(userToRemove, AgoraPermissions(Nothing))))
+            val accessControl = AccessControl(userToRemove, AgoraPermissions(Nothing))
+            complete(permissionBusiness.deleteEntityPermission(agoraEntity, username, userToRemove).map(_ => accessControl))
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/EntityPermissionsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/EntityPermissionsService.scala
@@ -13,8 +13,7 @@ import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.routes.{BaseRoute, RouteHelpers}
 import spray.json.DefaultJsonProtocol
 
-import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContextExecutor
 
 class EntityPermissionsService(dataSource: PermissionsDataSource) extends RouteHelpers with BaseRoute
   with Directives with SprayJsonSupport with DefaultJsonProtocol with LazyLogging {
@@ -30,42 +29,25 @@ class EntityPermissionsService(dataSource: PermissionsDataSource) extends RouteH
         parameterMap { (params) =>
           val agoraEntity = AgoraEntity(Option(namespace), Option(name), Option(snapshotId))
 
-          entity(as[List[AccessControl]]) { (listOfAccessControl) =>
+          entity(as[List[AccessControl]]) { acl =>
             post {
-              val message: Future[Int] = permissionBusiness.batchEntityPermission(agoraEntity, username, listOfAccessControl)
-              onComplete(message) {
-                case Success(m) => complete(listOfAccessControl)
-                case Failure(ex) => failWith(ex)
-              }
+              complete(permissionBusiness.batchEntityPermission(agoraEntity, username, acl).map(_ => acl))
             }
           } ~
           get {
-            val message: Future[Seq[AccessControl]] = permissionBusiness.listEntityPermissions(agoraEntity, username)
-            complete(message)
+            complete(permissionBusiness.listEntityPermissions(agoraEntity, username))
           } ~
           post {
             val accessObject = AccessControl.fromParams(params)
-            val message: Future[Int] = permissionBusiness.insertEntityPermission(agoraEntity, username, accessObject)
-            onComplete(message) {
-              case Success(m) => complete(accessObject)
-              case Failure(ex) => failWith(ex)
-            }
+            complete(permissionBusiness.insertEntityPermission(agoraEntity, username, accessObject).map(_ => accessObject))
           } ~
           put {
             val accessObject = AccessControl.fromParams(params)
-            val message: Future[Int] = permissionBusiness.editEntityPermission(agoraEntity, username, accessObject)
-            onComplete(message) {
-              case Success(m) => complete(accessObject)
-              case Failure(ex) => failWith(ex)
-            }
+            complete(permissionBusiness.editEntityPermission(agoraEntity, username, accessObject).map(_ => accessObject))
           } ~
           delete {
             val userToRemove = getUserFromParams(params)
-            val message: Future[Int] = permissionBusiness.deleteEntityPermission(agoraEntity, username, userToRemove)
-            onComplete(message) {
-              case Success(m) => complete(AccessControl(userToRemove, AgoraPermissions(Nothing)))
-              case Failure(ex) => failWith(ex)
-            }
+            complete(permissionBusiness.deleteEntityPermission(agoraEntity, username, userToRemove).map(_ => AccessControl(userToRemove, AgoraPermissions(Nothing))))
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/EntityPermissionsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/EntityPermissionsService.scala
@@ -31,7 +31,7 @@ class EntityPermissionsService(dataSource: PermissionsDataSource) extends RouteH
 
           entity(as[List[AccessControl]]) { acl =>
             post {
-              completeWith(acl)(permissionBusiness.batchEntityPermission(agoraEntity, username, acl))
+              completeVia(acl)(permissionBusiness.batchEntityPermission(agoraEntity, username, acl))
             }
           } ~
           get {
@@ -39,16 +39,16 @@ class EntityPermissionsService(dataSource: PermissionsDataSource) extends RouteH
           } ~
           post {
             val accessObject = AccessControl.fromParams(params)
-            completeWith(accessObject)(permissionBusiness.insertEntityPermission(agoraEntity, username, accessObject))
+            completeVia(accessObject)(permissionBusiness.insertEntityPermission(agoraEntity, username, accessObject))
           } ~
           put {
             val accessObject = AccessControl.fromParams(params)
-            completeWith(accessObject)(permissionBusiness.editEntityPermission(agoraEntity, username, accessObject))
+            completeVia(accessObject)(permissionBusiness.editEntityPermission(agoraEntity, username, accessObject))
           } ~
           delete {
             val userToRemove = getUserFromParams(params)
             val accessControl = AccessControl(userToRemove, AgoraPermissions(Nothing))
-            completeWith(accessControl)(permissionBusiness.deleteEntityPermission(agoraEntity, username, userToRemove))
+            completeVia(accessControl)(permissionBusiness.deleteEntityPermission(agoraEntity, username, userToRemove))
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/EntityPermissionsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/EntityPermissionsService.scala
@@ -31,7 +31,7 @@ class EntityPermissionsService(dataSource: PermissionsDataSource) extends RouteH
 
           entity(as[List[AccessControl]]) { acl =>
             post {
-              complete(permissionBusiness.batchEntityPermission(agoraEntity, username, acl).map(_ => acl))
+              completeWith(acl)(permissionBusiness.batchEntityPermission(agoraEntity, username, acl))
             }
           } ~
           get {
@@ -39,16 +39,16 @@ class EntityPermissionsService(dataSource: PermissionsDataSource) extends RouteH
           } ~
           post {
             val accessObject = AccessControl.fromParams(params)
-            complete(permissionBusiness.insertEntityPermission(agoraEntity, username, accessObject).map(_ => accessObject))
+            completeWith(accessObject)(permissionBusiness.insertEntityPermission(agoraEntity, username, accessObject))
           } ~
           put {
             val accessObject = AccessControl.fromParams(params)
-            complete(permissionBusiness.editEntityPermission(agoraEntity, username, accessObject).map(_ => accessObject))
+            completeWith(accessObject)(permissionBusiness.editEntityPermission(agoraEntity, username, accessObject))
           } ~
           delete {
             val userToRemove = getUserFromParams(params)
             val accessControl = AccessControl(userToRemove, AgoraPermissions(Nothing))
-            complete(permissionBusiness.deleteEntityPermission(agoraEntity, username, userToRemove).map(_ => accessControl))
+            completeWith(accessControl)(permissionBusiness.deleteEntityPermission(agoraEntity, username, userToRemove))
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/NamespacePermissionsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/NamespacePermissionsService.scala
@@ -29,7 +29,7 @@ class NamespacePermissionsService(dataSource: PermissionsDataSource) extends Rou
           val agoraEntity = AgoraEntity(Option(namespace))
           entity(as[List[AccessControl]]) { accessObjects =>
             post {
-              complete(permissionBusiness.batchNamespacePermission(agoraEntity, username, accessObjects).map(_ => accessObjects))
+              completeWith(accessObjects)(permissionBusiness.batchNamespacePermission(agoraEntity, username, accessObjects))
             }
           } ~
           get {
@@ -37,16 +37,16 @@ class NamespacePermissionsService(dataSource: PermissionsDataSource) extends Rou
           } ~
           post {
             val accessObject = AccessControl.fromParams(params)
-            complete(permissionBusiness.insertNamespacePermission(agoraEntity, username, accessObject).map(_ => accessObject))
+            completeWith(accessObject)(permissionBusiness.insertNamespacePermission(agoraEntity, username, accessObject))
           } ~
           put {
             val accessObject = AccessControl.fromParams(params)
-            complete(permissionBusiness.editNamespacePermission(agoraEntity, username, accessObject).map(_ => accessObject))
+            completeWith(accessObject)(permissionBusiness.editNamespacePermission(agoraEntity, username, accessObject))
           } ~
           delete {
             val userToRemove = getUserFromParams(params)
             val accessControl = AccessControl(userToRemove, AgoraPermissions(Nothing))
-            complete(permissionBusiness.deleteNamespacePermission(agoraEntity, username, userToRemove).map(_ => accessControl))
+            completeWith(accessControl)(permissionBusiness.deleteNamespacePermission(agoraEntity, username, userToRemove))
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/NamespacePermissionsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/NamespacePermissionsService.scala
@@ -13,8 +13,7 @@ import org.broadinstitute.dsde.agora.server.model.AgoraEntity
 import org.broadinstitute.dsde.agora.server.webservice.routes.{BaseRoute, RouteHelpers}
 import spray.json.DefaultJsonProtocol
 
-import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContextExecutor
 
 class NamespacePermissionsService(dataSource: PermissionsDataSource) extends RouteHelpers with BaseRoute
   with Directives with SprayJsonSupport with DefaultJsonProtocol with LazyLogging {
@@ -28,42 +27,26 @@ class NamespacePermissionsService(dataSource: PermissionsDataSource) extends Rou
       path("api" / AgoraConfig.version / ("configurations" | "methods") / Segment / "permissions") { namespace: String =>
         parameterMap { (params) =>
           val agoraEntity = AgoraEntity(Option(namespace))
-          entity(as[List[AccessControl]]) { (accessObjects) =>
+          entity(as[List[AccessControl]]) { accessObjects =>
             post {
-              val message: Future[Int] = permissionBusiness.batchNamespacePermission(agoraEntity, username, accessObjects)
-              onComplete(message) {
-                case Success(m) => complete(accessObjects)
-                case Failure(ex) => failWith(ex)
-              }
+              complete(permissionBusiness.batchNamespacePermission(agoraEntity, username, accessObjects).map(_ => accessObjects))
             }
           } ~
           get {
-            val message: Future[Seq[AccessControl]] = permissionBusiness.listNamespacePermissions(agoraEntity, username)
-            complete(message)
+            complete(permissionBusiness.listNamespacePermissions(agoraEntity, username))
           } ~
           post {
             val accessObject = AccessControl.fromParams(params)
-            val message: Future[Int] = permissionBusiness.insertNamespacePermission(agoraEntity, username, accessObject)
-            onComplete(message) {
-              case Success(m) => complete(accessObject)
-              case Failure(ex) => failWith(ex)
-            }
+            complete(permissionBusiness.insertNamespacePermission(agoraEntity, username, accessObject).map(_ => accessObject))
           } ~
           put {
             val accessObject = AccessControl.fromParams(params)
-            val message: Future[Int] = permissionBusiness.editNamespacePermission(agoraEntity, username, accessObject)
-            onComplete(message) {
-              case Success(m) => complete(accessObject)
-              case Failure(ex) => failWith(ex)
-            }
+            complete(permissionBusiness.editNamespacePermission(agoraEntity, username, accessObject).map(_ => accessObject))
           } ~
           delete {
             val userToRemove = getUserFromParams(params)
-            val message: Future[Int] = permissionBusiness.deleteNamespacePermission(agoraEntity, username, userToRemove)
-            onComplete(message) {
-              case Success(m) => complete(AccessControl(userToRemove, AgoraPermissions(Nothing)))
-              case Failure(ex) => failWith(ex)
-            }
+            val accessControl = AccessControl(userToRemove, AgoraPermissions(Nothing))
+            complete(permissionBusiness.deleteNamespacePermission(agoraEntity, username, userToRemove).map(_ => accessControl))
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/NamespacePermissionsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/permissions/NamespacePermissionsService.scala
@@ -29,7 +29,7 @@ class NamespacePermissionsService(dataSource: PermissionsDataSource) extends Rou
           val agoraEntity = AgoraEntity(Option(namespace))
           entity(as[List[AccessControl]]) { accessObjects =>
             post {
-              completeWith(accessObjects)(permissionBusiness.batchNamespacePermission(agoraEntity, username, accessObjects))
+              completeVia(accessObjects)(permissionBusiness.batchNamespacePermission(agoraEntity, username, accessObjects))
             }
           } ~
           get {
@@ -37,16 +37,16 @@ class NamespacePermissionsService(dataSource: PermissionsDataSource) extends Rou
           } ~
           post {
             val accessObject = AccessControl.fromParams(params)
-            completeWith(accessObject)(permissionBusiness.insertNamespacePermission(agoraEntity, username, accessObject))
+            completeVia(accessObject)(permissionBusiness.insertNamespacePermission(agoraEntity, username, accessObject))
           } ~
           put {
             val accessObject = AccessControl.fromParams(params)
-            completeWith(accessObject)(permissionBusiness.editNamespacePermission(agoraEntity, username, accessObject))
+            completeVia(accessObject)(permissionBusiness.editNamespacePermission(agoraEntity, username, accessObject))
           } ~
           delete {
             val userToRemove = getUserFromParams(params)
             val accessControl = AccessControl(userToRemove, AgoraPermissions(Nothing))
-            completeWith(accessControl)(permissionBusiness.deleteNamespacePermission(agoraEntity, username, userToRemove))
+            completeVia(accessControl)(permissionBusiness.deleteNamespacePermission(agoraEntity, username, userToRemove))
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/routes/RouteHelpers.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/routes/RouteHelpers.scala
@@ -1,10 +1,11 @@
 package org.broadinstitute.dsde.agora.server.webservice.routes
 
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.server._
 import org.broadinstitute.dsde.agora.server.AgoraConfig.{authenticationDirectives, version}
 import org.broadinstitute.dsde.agora.server.model.{AgoraEntity, AgoraEntityProjection, AgoraEntityType}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 trait RouteHelpers extends AddRouteHelper with QueryRouteHelper
@@ -19,6 +20,11 @@ trait BaseRoute extends RouteUtil  {
   }
 
   def versionedPath[L](pm: PathMatcher[L]): Directive[L] = path("api" / version / pm)
+
+  def completeWith[A](m: => ToResponseMarshallable)
+                     (f: => Future[A])
+                     (implicit ec: ExecutionContext): StandardRoute =
+    complete(f.map(_ => m))
 }
 
 trait QueryRouteHelper extends BaseRoute {

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/routes/RouteHelpers.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/routes/RouteHelpers.scala
@@ -21,9 +21,9 @@ trait BaseRoute extends RouteUtil  {
 
   def versionedPath[L](pm: PathMatcher[L]): Directive[L] = path("api" / version / pm)
 
-  def completeWith[A](m: => ToResponseMarshallable)
-                     (f: => Future[A])
-                     (implicit ec: ExecutionContext): StandardRoute =
+  def completeVia[A](m: => ToResponseMarshallable)
+                    (f: => Future[A])
+                    (implicit ec: ExecutionContext): StandardRoute =
     complete(f.map(_ => m))
 }
 


### PR DESCRIPTION
- Addresses the PR feedback for #238 
- Removes redundant `Future` `Failure` handling in request `complete`ions where we passed `Throwable`s through without modification. 
- Removes `onComplete`s where above applies and the content of `Future` `Success` is not further processed.