### PR TITLE
Print out why status check failed [WA-45]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/StatusService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/StatusService.scala
@@ -33,8 +33,8 @@ class StatusService(permissionsDataSource: PermissionsDataSource, healthMonitor:
         case Success(status) =>
           val httpCode = if (status.ok) OK else InternalServerError
           complete(httpCode, status)
-        case Failure(_) =>
-          val agoraStatus = SubsystemStatus(ok = false, Some(List("Unable to gather subsystem status")))
+        case Failure(t) =>
+          val agoraStatus = SubsystemStatus(ok = false, Some(List(s"Unable to gather subsystem status: ${t.getMessage}")))
           complete(InternalServerError, StatusCheckResponse(ok = false, Map(Subsystems.Agora -> agoraStatus)))
       }
     }


### PR DESCRIPTION
Right now I'm looking at an instance that reports
```
{"ok":false,"systems":{"Agora":{"ok":false,"messages":["Unable to gather subsystem status"]}}}
```
which is not very helpful in solving the problem.