### PR TITLE
Cache entity aliases [WA-77]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AdminPermissionsClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AdminPermissionsClient.scala
@@ -11,5 +11,5 @@ class AdminPermissionsClient(profile: JdbcProfile) extends PermissionsClient(pro
   def listAdminUsers()(implicit executionContext: ExecutionContext): ReadWriteAction[Seq[String]] = listAdmins()
 
   def alias(entity: AgoraEntity): String =
-    entity.namespace.get + "." + entity.name.get + "." + entity.snapshotId.get
+    entity.entityAlias
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraEntityPermissionsClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraEntityPermissionsClient.scala
@@ -9,7 +9,7 @@ import scala.concurrent.ExecutionContext
 class AgoraEntityPermissionsClient(profile: JdbcProfile) extends PermissionsClient(profile) {
 
   def alias(entity: AgoraEntity): String =
-    entity.namespace.get + "." + entity.name.get + "." + entity.snapshotId.get
+    entity.entityAlias
 
   def getEntityPermission(entity: AgoraEntity, userEmail: String)
                          (implicit executionContext: ExecutionContext): ReadWriteAction[AgoraPermissions] =

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/NamespacePermissionsClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/NamespacePermissionsClient.scala
@@ -9,7 +9,7 @@ import scala.concurrent.ExecutionContext
 class NamespacePermissionsClient(profile: JdbcProfile) extends PermissionsClient(profile) {
 
   def alias(entity: AgoraEntity): String =
-    entity.namespace.get
+    entity.namespaceAlias
 
   def getNamespacePermission(entity: AgoraEntity, userEmail: String)
                             (implicit executionContext: ExecutionContext): ReadWriteAction[AgoraPermissions] =

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/model/AgoraEntity.scala
@@ -133,6 +133,12 @@ case class AgoraEntity(namespace: Option[String] = None,
                        managers: Seq[String] = Seq(),
                        public: Option[Boolean] = None) {
 
+  lazy val entityAlias: String =
+    namespace.get + "." + name.get + "." + snapshotId.get
+
+  lazy val namespaceAlias: String =
+    namespace.get
+
   def agoraUrl: String = {
     AgoraConfig.urlFromType(entityType) + namespace.get + "/" + name.get + "/" + snapshotId.get
   }


### PR DESCRIPTION
This changeset relocates an often-performed string concatenation behind a `lazy val`.

Profiling Agora under load to the `/definitions` endpoint showed that we were spending a surprising amount of CPU converting the `snapshotId` integer to string, for example.