### PR TITLE
BW-1170: Update logback past vulnerable v1.2.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ resolvers += "artifactory-releases" at artifactory + "libs-release"
 resolvers += "artifactory-snapshots" at artifactory + "libs-snapshot"
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "ch.qos.logback" % "logback-classic" % "1.2.11",
   "com.google.api-client" % "google-api-client" % "1.25.0" excludeAll ExclusionRule(organization = "com.google.guava"),
   "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev118-1.25.0" excludeAll
     ExclusionRule(organization = "com.google.guava"),


### PR DESCRIPTION
Note: Ticket [BW-1170](https://broadworkbench.atlassian.net/browse/BW-1170) noted that the latest version of logback is now `1.3.0-alpha14`. I chose to update to 1.2.11 because:
1. Lower risk of unexpected changes by staying in the 1.2.x versions
2. Lower risk of unexpected changes by not choosing an alpha version
3. The [vulnerability report](https://nvd.nist.gov/vuln/detail/CVE-2021-42550) says that the problem was resolved after 1.2.7

Proof of update (required `addDependencyTreePlugin` in `plugins.sbt`:

```sbt
sbt:Agora> whatDependsOn ch.qos.logback logback-classic 1.2.3
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[success] Total time: 1 s, completed Jun 3, 2022, 3:34:33 PM
sbt:Agora> whatDependsOn ch.qos.logback logback-core 1.2.3
[error] Expected '1.2.11'
[error] whatDependsOn ch.qos.logback logback-core 1.2.3
[error]                                               ^
sbt:Agora> whatDependsOn ch.qos.logback logback-core 1.2.11
[info] ch.qos.logback:logback-core:1.2.11
[info]   +-ch.qos.logback:logback-classic:1.2.11
[info]     +-org.broadinstitute:agora_2.13:0.1.0-SNAPSHOT [S]
[info]
[success] Total time: 0 s, completed Jun 3, 2022, 3:34:52 PM
```