### PR TITLE
DDO-2398 Publish mutable tag names to GCR

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -119,7 +119,7 @@ function docker_cmd()
                 docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${HASH_TAG}
                 ## Next line replaced with docker_content_trust_sign_app_image.
                 gcloud docker -- push $GCR_REGISTRY:${HASH_TAG}
-                gcloud container images add-tag $GCR_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${DOCKERTAG_SAFE_NAME}
+                gcloud container images add-tag $GCR_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${BRANCH}
             fi
         fi
     else

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -115,9 +115,11 @@ function docker_cmd()
             docker push $DOCKERHUB_REGISTRY:${BRANCH}
 
             if [[ -n $GCR_REGISTRY ]]; then
+                echo "pushing $GCR_REGISTRY:${HASH_TAG}..."
                 docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${HASH_TAG}
                 ## Next line replaced with docker_content_trust_sign_app_image.
                 gcloud docker -- push $GCR_REGISTRY:${HASH_TAG}
+                gcloud container images add-tag $GCR_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${DOCKERTAG_SAFE_NAME}
             fi
         fi
     else


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-2398

This change propagates PR branch floating image tags to GCR as well as Docker hub.

The recent cutover to BEEs revealed in incompatibility with their orchestration and the PR-fiab-test Jenkins pipelines. This change should fix the issue.

More context in this Slack thread: https://broadinstitute.slack.com/archives/C029LTN5L80/p1665502394560979