### PR TITLE
[DDO-2875] Fix Agora entrypoint so that Agora shuts down

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,8 @@ COPY --from=builder /agora/agora.jar /agora/
 COPY --from=builder /agora/docker/run.sh /agora/docker/
 COPY --from=builder /agora/src/main/resources/db/migration/ /agora/src/migration
 
-ENTRYPOINT ["/agora/docker/run.sh"]
+# 1. "Exec" form of CMD necessary to avoid `sh` stripping environment variables with periods in them,
+#    used for Lightbend config
+# 2. $JAVA_OPTS required for configuration
+# We use the "exec" form but call `bash` to accomplish both 1 and 2
+CMD ["/bin/bash", "-c", "java $JAVA_OPTS -Dconfig.file=/etc/agora.conf -jar /agora/agora.jar"]


### PR DESCRIPTION
Agora's entrypoint calls a [shell script that turns around and runs the jar](https://github.com/broadinstitute/agora/blob/develop/docker/run.sh).

This is very bad practice because [bash does not propagate the shutdown SIGTERM signal](https://unix.stackexchange.com/questions/146756/forward-sigterm-to-child-in-bash/196053#196053). This means that Agora never shuts down and runs continuously until the container runtime forcibly kills it.

This means that Agora's [shutdown hook](https://github.com/broadinstitute/agora/blob/develop/src/main/scala/org/broadinstitute/dsde/agora/server/Agora.scala#L12) never runs. You can check logs for the shutdown hook's "Stopping server" message to see that it never runs. You can also check logs for the Cloud SQL Proxy's "active connections still exist after waiting for 30s" error message, further indicating that the app never shuts down when told to.

This PR adopts the same command as apps like [Leonardo](https://github.com/DataBiosphere/leonardo/blob/develop/Dockerfile#L91) and [Sam](https://github.com/broadinstitute/sam/blob/develop/Dockerfile#L23), which propagates the signal.