### PR TITLE
[WM-2065] Disallow emails with non-latin characters

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusiness.scala
@@ -209,7 +209,7 @@ class AgoraBusiness(permissionsDataSource: PermissionsDataSource) extends LazyLo
               }
 
               entityToInsertAction flatMap { entityToInsert =>
-                val userAccess = new AccessControl(username, AgoraPermissions(All))
+                val userAccess = AccessControl(username, AgoraPermissions(All))
 
                 for {
                   entityWithId <-

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AccessControl.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AccessControl.scala
@@ -7,7 +7,10 @@ object AccessControl {
   def apply(accessObject: Tuple2[String, Int]): AccessControl = {
     val user = accessObject._1
     val permission = AgoraPermissions(accessObject._2)
-    AccessControl(user, permission)
+    if ("""[a-zA-Z0-9-_\.@]*""".r.matches(user))
+      AccessControl(user, permission)
+    else
+      throw new IllegalArgumentException("User contains invalid characters.")
   }
 
   def fromParams(params: Map[String, String]): AccessControl = {

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AccessControl.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AccessControl.scala
@@ -7,10 +7,7 @@ object AccessControl {
   def apply(accessObject: Tuple2[String, Int]): AccessControl = {
     val user = accessObject._1
     val permission = AgoraPermissions(accessObject._2)
-    if ("""[a-zA-Z0-9-_\.@]*""".r.matches(user))
-      AccessControl(user, permission)
-    else
-      throw new IllegalArgumentException("User contains invalid characters.")
+    AccessControl(user, permission)
   }
 
   def fromParams(params: Map[String, String]): AccessControl = {
@@ -26,6 +23,8 @@ object AccessControl {
   final val publicUser:String = "public"
 }
 
-case class AccessControl(user: String, roles: AgoraPermissions)
+case class AccessControl(user: String, roles: AgoraPermissions) {
+  require("""[a-zA-Z0-9-_\.@]*""".r.matches(user), "User contains invalid characters.")
+}
 
 case class EntityAccessControl(entity: AgoraEntity, acls: Seq[AccessControl], message: Option[String] = None)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -53,6 +53,7 @@ object AgoraTestData {
   val owner1 = Option("testowner1@broadinstitute.org")
   val owner2 = Option("testowner2@broadinstitute.org")
   val owner3 = Option("testowner3@broadinstitute.org")
+  val maliciousOwner = Option("mal%C4%B1c%C4%B1ous@broadinstitute.org")
   val adminUser = Option("admin@broadinstitute.org")
   val mockAuthenticatedOwner = Option(AgoraConfig.mockAuthenticatedUserEmail)
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -703,6 +703,13 @@ object AgoraTestData {
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 
+  val testMaliciousOwnerEntity = AgoraEntity(namespace = Option("___test4"),
+    name = Option("testWorkflow4"),
+    documentation = documentation1,
+    owner = maliciousOwner,
+    payload = payload1,
+    entityType = Option(AgoraEntityType.Workflow))
+
   val testAgoraEntityWithValidOfficialDockerImageInWdl = new AgoraEntity(namespace = Option("___docker_test"),
     name = name1,
     synopsis = synopsis1,

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/AgoraTestData.scala
@@ -53,7 +53,6 @@ object AgoraTestData {
   val owner1 = Option("testowner1@broadinstitute.org")
   val owner2 = Option("testowner2@broadinstitute.org")
   val owner3 = Option("testowner3@broadinstitute.org")
-  val maliciousOwner = Option("mal%C4%B1c%C4%B1ous@broadinstitute.org")
   val adminUser = Option("admin@broadinstitute.org")
   val mockAuthenticatedOwner = Option(AgoraConfig.mockAuthenticatedUserEmail)
 
@@ -700,13 +699,6 @@ object AgoraTestData {
     synopsis = synopsis3,
     documentation = documentation1,
     owner = owner3,
-    payload = payload1,
-    entityType = Option(AgoraEntityType.Workflow))
-
-  val testMaliciousOwnerEntity = AgoraEntity(namespace = Option("___test4"),
-    name = Option("testWorkflow4"),
-    documentation = documentation1,
-    owner = maliciousOwner,
     payload = payload1,
     entityType = Option(AgoraEntityType.Workflow))
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/business/AgoraBusinessTest.scala
@@ -82,7 +82,7 @@ class AgoraBusinessTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
     patiently(permsDataSource.inTransaction { db =>
       DBIOAction.seq(
         db.aePerms.addEntity(testAgoraEntityWithIllegalNameChars),
-        db.aePerms.insertEntityPermission(testAgoraEntityWithIllegalNameChars, new AccessControl(mockAuthenticatedOwner.get, AgoraPermissions(Read)))
+        db.aePerms.insertEntityPermission(testAgoraEntityWithIllegalNameChars, AccessControl(mockAuthenticatedOwner.get, AgoraPermissions(Read)))
       )
     })
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/EntityPermissionsClientSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/EntityPermissionsClientSpec.scala
@@ -143,21 +143,21 @@ class EntityPermissionsClientSpec extends AnyFlatSpec with ScalaFutures with Bef
   }
 
   "Agora" should "allow batch permission edits" in {
-    val accessObject1 = new AccessControl(owner1.get, AgoraPermissions(AgoraPermissions.All))
-    val accessObject2 = new AccessControl(owner2.get, AgoraPermissions(AgoraPermissions.Nothing))
+    val accessObject1 = AccessControl(owner1.get, AgoraPermissions(AgoraPermissions.All))
+    val accessObject2 = AccessControl(owner2.get, AgoraPermissions(AgoraPermissions.Nothing))
     val rowsEditted = patiently(permissionBusiness.batchEntityPermission(testBatchPermissionEntity, mockAuthenticatedOwner.get, List(accessObject1, accessObject2)))
     assert(rowsEditted == 2)
   }
 
   "Agora" should "prevent a user from overwriting their own entity permission" in {
-    val accessObject = new AccessControl(mockAuthenticatedOwner.get, AgoraPermissions(AgoraPermissions.Nothing))
+    val accessObject = AccessControl(mockAuthenticatedOwner.get, AgoraPermissions(AgoraPermissions.Nothing))
     intercept[PermissionModificationException] {
       patiently(permissionBusiness.insertEntityPermission(testBatchPermissionEntity, mockAuthenticatedOwner.get, accessObject))
     }
   }
 
   "Agora" should "prevent a user from modifying their own entity permission" in {
-    val accessObject = new AccessControl(mockAuthenticatedOwner.get, AgoraPermissions(AgoraPermissions.Nothing))
+    val accessObject = AccessControl(mockAuthenticatedOwner.get, AgoraPermissions(AgoraPermissions.Nothing))
     intercept[PermissionModificationException] {
       patiently(permissionBusiness.editEntityPermission(testBatchPermissionEntity, mockAuthenticatedOwner.get, accessObject))
     }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/NamespacePermissionsClientSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/NamespacePermissionsClientSpec.scala
@@ -106,21 +106,21 @@ class NamespacePermissionsClientSpec extends AnyFlatSpec with ScalaFutures with 
   }
 
   "Agora" should "allow batch permission edits" in {
-    val accessObject1 = new AccessControl(owner1.get, AgoraPermissions(AgoraPermissions.All))
-    val accessObject2 = new AccessControl(owner2.get, AgoraPermissions(AgoraPermissions.Nothing))
+    val accessObject1 = AccessControl(owner1.get, AgoraPermissions(AgoraPermissions.All))
+    val accessObject2 = AccessControl(owner2.get, AgoraPermissions(AgoraPermissions.Nothing))
     val rowsEditted = patiently(permissionBusiness.batchNamespacePermission(testBatchPermissionEntityWithId, mockAuthenticatedOwner.get, List(accessObject1, accessObject2)))
     assert(rowsEditted == 2)
   }
 
   "Agora" should "prevent a user from overwriting their own namespace permission" in {
-    val accessObject = new AccessControl(owner1.get, AgoraPermissions(AgoraPermissions.Nothing))
+    val accessObject = AccessControl(owner1.get, AgoraPermissions(AgoraPermissions.Nothing))
     intercept[PermissionModificationException] {
       patiently(permissionBusiness.insertNamespacePermission(testEntity1, owner1.get, accessObject))
     }
   }
 
   "Agora" should "prevent a user from modifying their own namespace permission" in {
-    val accessObject = new AccessControl(owner1.get, AgoraPermissions(AgoraPermissions.Nothing))
+    val accessObject = AccessControl(owner1.get, AgoraPermissions(AgoraPermissions.Nothing))
     intercept[PermissionModificationException] {
       patiently(permissionBusiness.editNamespacePermission(testEntity1, owner1.get, accessObject))
     }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraConfigurationsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/AgoraConfigurationsSpec.scala
@@ -171,7 +171,7 @@ class AgoraConfigurationsSpec extends ApiServiceSpec with AnyFlatSpecLike with A
   }
 
   "Agora" should "not allow you to post a new configuration if you don't have permission to read the method that it references" in {
-    val noPermission = new AccessControl(AgoraConfig.mockAuthenticatedUserEmail, AgoraPermissions(AgoraPermissions.Nothing))
+    val noPermission = AccessControl(AgoraConfig.mockAuthenticatedUserEmail, AgoraPermissions(AgoraPermissions.Nothing))
     runInDB { db =>
       db.aePerms.editEntityPermission(method1, noPermission)
     }

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -211,20 +211,6 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
       }
   }
 
-  "Agora" should "not allow users to insert permissions with non-latin characters." in {
-    val entityJSON = s"""{
-                        | "user": "malıcıous@broadınstıtute.org",
-                        | "roles": "All",
-                        |}""".stripMargin
-    Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions", HttpEntity(contentType = ContentTypes.`application/json`,
-      string = entityJSON)) ~>
-      routes ~>
-      check {
-        assert(status == BadRequest)
-      }
-  }
-
   "Agora" should "allow authorized users to edit an existing entity permissions." in {
 
     Put(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -213,7 +213,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow users to insert permissions with non-latin characters." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + "?user=malıcıous@broadınstıtute.org&roles=All") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + "?user=mal%C4%B1c%C4%B1ous@broadinstitute.org&roles=All") ~>
       routes ~>
       check {
         assert(status == BadRequest)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -213,7 +213,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow users to insert permissions with non-latin characters." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + agoraEntity2.name.get +
-      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=malıcıous@broadınstıtute.org&roles=All") ~>
+      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=$maliciousOwner&roles=All") ~>
       routes ~>
       check {
         assert(status == BadRequest)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.agora.server.webservice
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -36,7 +36,6 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   var agoraEntity1: AgoraEntity = _
   var agoraEntity2: AgoraEntity = _
   var agoraEntity3: AgoraEntity = _
-  var agoraEntity4: AgoraEntity = _
   var redactedEntity: AgoraEntity = _
 
   override def beforeAll(): Unit = {
@@ -46,7 +45,6 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
     agoraEntity1 = patiently(agoraBusiness.insert(testIntegrationEntity, mockAuthenticatedOwner.get, mockAccessToken))
     agoraEntity2 = patiently(agoraBusiness.insert(testIntegrationEntity2, owner2.get, mockAccessToken))
     agoraEntity3 = patiently(agoraBusiness.insert(testIntegrationEntity3, mockAuthenticatedOwner.get, mockAccessToken))
-    agoraEntity4 = patiently(agoraBusiness.insert(testMaliciousOwnerEntity, mockAuthenticatedOwner.get, mockAccessToken))
 
     redactedEntity = patiently(agoraBusiness.insert(testEntityToBeRedacted2, mockAuthenticatedOwner.get, mockAccessToken))
     patiently(agoraBusiness.delete(redactedEntity, Seq(redactedEntity.entityType.get), mockAuthenticatedOwner.get))
@@ -214,8 +212,8 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
 
   "Agora" should "not allow users to insert permissions with non-latin characters." in {
 
-    Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity4.namespace.get + "/" + agoraEntity4.name.get +
-      "/" + agoraEntity4.snapshotId.get + "/" + "permissions" + s"?user=$maliciousOwner&roles=All") ~>
+    Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + "?user=malıcıous@broadınstıtute.org&roles=All") ~>
       routes ~>
       check {
         assert(status == BadRequest)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -77,7 +77,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to insert multiple roles in a single namespace permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + "permissions" +
-      s"?user=${owner2.get}&roles=Read,Create,Manage") ~>
+      s"?user=$owner2&roles=Read,Create,Manage") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -98,7 +98,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to insert a namespace permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + "permissions" +
-      s"?user=${owner2.get}&roles=All") ~>
+      s"?user=$owner2&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)
@@ -108,7 +108,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "only allow authorized users to overwrite existing permissions." in {
 
     Put(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + "permissions" +
-      s"?user=${owner2.get}&roles=Read") ~>
+      s"?user=$owner2&roles=Read") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -129,7 +129,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to delete an existing namespace permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + "permissions" +
-      s"?user=${owner2.get}&roles=Read") ~>
+      s"?user=$owner2&roles=Read") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -150,7 +150,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to delete an existing namespace permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + "permissions" +
-      s"?user=${owner2.get}&roles=All") ~>
+      s"?user=$owner2&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)
@@ -182,7 +182,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to insert a entity permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=All") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=All") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -213,7 +213,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to edit an existing entity permissions." in {
 
     Put(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=Read") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=Read") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -234,7 +234,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to delete an existing entity permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=All") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=All") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -255,7 +255,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to delete an existing entity permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + agoraEntity2.name.get +
-      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=All") ~>
+      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -77,7 +77,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to insert multiple roles in a single namespace permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=Read,Create,Manage") ~>
+      s"?user=${owner2.get}&roles=Read,Create,Manage") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -98,7 +98,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to insert a namespace permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=All") ~>
+      s"?user=${owner2.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)
@@ -108,7 +108,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "only allow authorized users to overwrite existing permissions." in {
 
     Put(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=Read") ~>
+      s"?user=${owner2.get}&roles=Read") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -129,7 +129,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to delete an existing namespace permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=Read") ~>
+      s"?user=${owner2.get}&roles=Read") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -150,7 +150,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to delete an existing namespace permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=All") ~>
+      s"?user=${owner2.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)
@@ -182,7 +182,18 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to insert a entity permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=All") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=All") ~>
+      routes ~>
+      check {
+        assert(status == OK)
+        assert(responseAs[String] contains "Manage")
+      }
+  }
+
+  "Agora" should "not allow authorized users to insert an entity permission with non-latin characters." in {
+
+    Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=mal%C4%B1c%C4%B1ous@broadinstitute.org&roles=All") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -203,7 +214,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to insert a entity permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + agoraEntity2.name.get +
-      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=$agoraTestOwner&roles=All") ~>
+      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=${agoraTestOwner.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)
@@ -213,7 +224,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to edit an existing entity permissions." in {
 
     Put(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=Read") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=Read") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -234,7 +245,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to delete an existing entity permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=All") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -255,7 +266,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to delete an existing entity permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + agoraEntity2.name.get +
-      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=All") ~>
+      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -36,6 +36,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   var agoraEntity1: AgoraEntity = _
   var agoraEntity2: AgoraEntity = _
   var agoraEntity3: AgoraEntity = _
+  var agoraEntity4: AgoraEntity = _
   var redactedEntity: AgoraEntity = _
 
   override def beforeAll(): Unit = {
@@ -45,6 +46,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
     agoraEntity1 = patiently(agoraBusiness.insert(testIntegrationEntity, mockAuthenticatedOwner.get, mockAccessToken))
     agoraEntity2 = patiently(agoraBusiness.insert(testIntegrationEntity2, owner2.get, mockAccessToken))
     agoraEntity3 = patiently(agoraBusiness.insert(testIntegrationEntity3, mockAuthenticatedOwner.get, mockAccessToken))
+    agoraEntity4 = patiently(agoraBusiness.insert(testMaliciousOwnerEntity, mockAuthenticatedOwner.get, mockAccessToken))
 
     redactedEntity = patiently(agoraBusiness.insert(testEntityToBeRedacted2, mockAuthenticatedOwner.get, mockAccessToken))
     patiently(agoraBusiness.delete(redactedEntity, Seq(redactedEntity.entityType.get), mockAuthenticatedOwner.get))
@@ -212,8 +214,8 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
 
   "Agora" should "not allow users to insert permissions with non-latin characters." in {
 
-    Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + agoraEntity2.name.get +
-      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=$maliciousOwner&roles=All") ~>
+    Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity4.namespace.get + "/" + agoraEntity4.name.get +
+      "/" + agoraEntity4.snapshotId.get + "/" + "permissions" + s"?user=$maliciousOwner&roles=All") ~>
       routes ~>
       check {
         assert(status == BadRequest)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -210,6 +210,16 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
       }
   }
 
+  "Agora" should "not allow users to insert permissions with non-latin characters." in {
+
+    Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + agoraEntity2.name.get +
+      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=malıcıous@broadınstıtute.org&roles=All") ~>
+      routes ~>
+      check {
+        assert(status == BadRequest)
+      }
+  }
+
   "Agora" should "allow authorized users to edit an existing entity permissions." in {
 
     Put(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.agora.server.webservice
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
@@ -211,9 +212,13 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   }
 
   "Agora" should "not allow users to insert permissions with non-latin characters." in {
-
+    val entityJSON = s"""{
+                        | "user": "malıcıous@broadınstıtute.org",
+                        | "roles": "All",
+                        |}""".stripMargin
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + "?user=mal%C4%B1c%C4%B1ous@broadinstitute.org&roles=All") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions", HttpEntity(contentType = ContentTypes.`application/json`,
+      string = entityJSON)) ~>
       routes ~>
       check {
         assert(status == BadRequest)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -77,7 +77,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to insert multiple roles in a single namespace permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=Read,Create,Manage") ~>
+      s"?user=${owner2.get}&roles=Read,Create,Manage") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -98,7 +98,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to insert a namespace permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=All") ~>
+      s"?user=${owner2.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)
@@ -108,7 +108,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "only allow authorized users to overwrite existing permissions." in {
 
     Put(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=Read") ~>
+      s"?user=${owner2.get}&roles=Read") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -129,7 +129,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to delete an existing namespace permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=Read") ~>
+      s"?user=${owner2.get}&roles=Read") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -150,7 +150,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to delete an existing namespace permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + "permissions" +
-      s"?user=$owner2&roles=All") ~>
+      s"?user=${owner2.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)
@@ -182,7 +182,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to insert a entity permissions." in {
 
     Post(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=All") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -223,7 +223,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to edit an existing entity permissions." in {
 
     Put(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=Read") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=Read") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -244,7 +244,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "allow authorized users to delete an existing entity permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity1.namespace.get + "/" + agoraEntity1.name.get +
-      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=All") ~>
+      "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == OK)
@@ -265,7 +265,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
   "Agora" should "not allow unauthorized users to delete an existing entity permissions." in {
 
     Delete(ApiUtil.Methods.withLeadingVersion + "/" + agoraEntity2.namespace.get + "/" + agoraEntity2.name.get +
-      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=$owner2&roles=All") ~>
+      "/" + agoraEntity2.snapshotId.get + "/" + "permissions" + s"?user=${owner2.get}&roles=All") ~>
       routes ~>
       check {
         assert(status == Forbidden)

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/webservice/PermissionIntegrationSpec.scala
@@ -196,8 +196,7 @@ class PermissionIntegrationSpec extends AnyFlatSpec with ScalatestRouteTest with
       "/" + agoraEntity1.snapshotId.get + "/" + "permissions" + s"?user=mal%C4%B1c%C4%B1ous@broadinstitute.org&roles=All") ~>
       routes ~>
       check {
-        assert(status == OK)
-        assert(responseAs[String] contains "Manage")
+        assert(status == BadRequest)
       }
   }
 


### PR DESCRIPTION
Verified that examples such as `♥`, `bołądź`, and `ı` now throw errors via bee's firecloudorch swagger. May want someone with firecloud/prod suitability to help on Tuesday to confirm if any examples of these exist in prod already that we should be looking for alternative solutions for.