### PR TITLE
WX-1807 Modernize Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Production build/deploy/start of DSDE Methods Repository Webservice
 
-FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.22_7_1.9.9_2.13.13 as builder
+# TODO: adopt `sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.22_7_1.9.9_2.13.13`
+# Currently using the very outdated http://github.com/broadinstitute/scala-baseimage
+# because the Docker version on Jenkins is obsolete and does not support recent images.
+FROM broadinstitute/scala-baseimage as builder
 
 # Install Agora
 ADD . /agora

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 # Production build/deploy/start of DSDE Methods Repository Webservice
 
-# http://github.com/broadinstitute/scala-baseimage
-FROM broadinstitute/scala-baseimage as builder
+FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.22_7_1.9.9_2.13.13 as builder
 
 # Install Agora
 ADD . /agora
 RUN ["/bin/bash", "-c", "/agora/docker/install.sh /agora"]
 
-FROM adoptopenjdk:11-hotspot
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
 
 # Expose the port used by Agora webservice
 EXPOSE 8000

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "Agora"
 
 organization := "org.broadinstitute"
 
-scalaVersion := "2.13.9"
+scalaVersion := "2.13.13"
 
 // Ported from Cromwell 2019-11-19
 // The disabled ones are not too crazy to get compliant with, but more work than I want to do just now (AEN)

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/package.scala
@@ -3,5 +3,5 @@ package org.broadinstitute.dsde.agora
 import org.broadinstitute.dsde.workbench.model.ErrorReportSource
 
 package object server {
-  implicit val errorReportSource = ErrorReportSource("agora")
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("agora")
 }

--- a/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/DockerHubJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/agora/server/webservice/util/DockerHubJsonSupport.scala
@@ -1,8 +1,8 @@
 package org.broadinstitute.dsde.agora.server.webservice.util
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import spray.json.DefaultJsonProtocol
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 
 object DockerHubJsonSupport extends DefaultJsonProtocol with SprayJsonSupport {
-  implicit val DockerTagInfoFormat = jsonFormat2(DockerTagInfo)
+  implicit val DockerTagInfoFormat: RootJsonFormat[DockerTagInfo] = jsonFormat2(DockerTagInfo)
 }


### PR DESCRIPTION
In scope:
- Update Docker runtime to DSP official image for Java 11
  - Main goal of [WX-1807](https://broadworkbench.atlassian.net/browse/WX-1807) ticket
  - Replaces Ubuntu 20.04 with 22.04
- ~~Update Docker builder to a modern image from SBT maintainers~~ Cannot due to Jenkins
  - ~~Replaces Ubuntu 14.04 (!) with 22.04~~
  - Upgrade Scala minor version to match builder
  - Fix minor build issues required for Scala minor version

Out of scope:
- Upgrade to Java 17

---

### Runtime

Before

```
> docker run -it --entrypoint /bin/bash adoptopenjdk:11-hotspot
root@c614de33bae8:/# cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.3 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.3 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

After

```
> docker run -it --entrypoint /bin/bash us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
root@c453e78a7eab:/# cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.4 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.4 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```

### Builder

Before

```
> docker run -it --entrypoint /bin/bash broadinstitute/scala-baseimage
root@7f0b61bf2337:/# cat /etc/os-release
NAME="Ubuntu"
VERSION="14.04.2 LTS, Trusty Tahr"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 14.04.2 LTS"
VERSION_ID="14.04"
HOME_URL="http://www.ubuntu.com/"
SUPPORT_URL="http://help.ubuntu.com/"
BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
```

After

```
> docker run -it --entrypoint /bin/bash sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.22_7_1.9.9_2.13.13
root@78c0bb8a8e5e:~# cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.4 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.4 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```

[WX-1807]: https://broadworkbench.atlassian.net/browse/WX-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ