### PR TITLE
AN-341 Fix local `sbt test`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ val akkaV = "2.6.9"
 val akkaHttpV = "10.2.9"
 val jacksonV = "2.11.3"
 val slickV = "3.3.3"
-val testcontainersScalaV = "0.38.4"
+val testcontainersScalaV = "0.41.8"
 
 val artifactory = "https://broadinstitute.jfrog.io/broadinstitute/"
 

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/TestAgoraMongoClient.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/mongo/TestAgoraMongoClient.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.agora.server.dataaccess.mongo
 
 import com.dimafeng.testcontainers.MongoDBContainer
+import org.testcontainers.utility.DockerImageName
 import com.mongodb.ConnectionString
 import com.typesafe.scalalogging.StrictLogging
 import org.broadinstitute.dsde.agora.server.AgoraConfig
@@ -16,7 +17,7 @@ object TestAgoraMongoClient extends StrictLogging {
   // Start up in the object static initializer so that we can set AgoraMongoClient.testConnectionString
   {
     if (AgoraConfig.mongoDbTestContainerEnabled) {
-      val imageName = "mongo:4.4"
+      val imageName = DockerImageName.parse("mongo:4.4")
       val mongoDBContainer = MongoDBContainer(imageName)
 
       // We may remove this when this is released:


### PR DESCRIPTION
It seems that newer versions of `docker` (or something) require an updated TestContainers.

The new TestContainers had a minor breaking syntax change which I took care of.

My local config is `docker` version `27.5.1` with Podman Engine `5.0.2`.

![Screenshot 2025-01-24 at 12 16 05](https://github.com/user-attachments/assets/bfb5b28a-24cc-4eb5-bbd9-842346a7a155)