### PR TITLE
[AN-341] Pin CI to use MySQL 8.0.40

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,8 +89,7 @@ libraryDependencies ++= Seq(
   "org.mock-server" % "mockserver-netty" % "5.11.1" % Test,
   "com.dimafeng" %% "testcontainers-scala-mysql" % testcontainersScalaV % Test,
   "com.dimafeng" %% "testcontainers-scala-mongodb" % testcontainersScalaV % Test,
-  "org.flywaydb" % "flyway-core" % "9.22.3" % Test, // Starting 10.0.0 Flyway only supports Java 17. Agora is on Java 11
-  "org.flywaydb" % "flyway-mysql" % "9.22.3" % Test,
+  "org.flywaydb" % "flyway-core" % "7.3.2" % Test, // Starting 10.0.0 Flyway only supports Java 17. Agora is on Java 11
   "org.broadinstitute.dsde.workbench" % "sam-client_2.12" % "0.1-61135c7",      // Should become available for 2.13 once a release happens ( https://github.com/broadinstitute/sam/pull/491 )
   "org.broadinstitute.cromwell" % "cromwell-client_2.12" % "0.1-8b413b45f-SNAP", // Contains only Java, pinning on 2.12
   "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V excludeAll(

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ libraryDependencies ++= Seq(
   "org.mock-server" % "mockserver-netty" % "5.11.1" % Test,
   "com.dimafeng" %% "testcontainers-scala-mysql" % testcontainersScalaV % Test,
   "com.dimafeng" %% "testcontainers-scala-mongodb" % testcontainersScalaV % Test,
-  "org.flywaydb" % "flyway-core" % "7.3.2" % Test, // Starting 10.0.0 Flyway only supports Java 17. Agora is on Java 11
+  "org.flywaydb" % "flyway-core" % "7.3.2" % Test, // Starting 10.0.0 Flyway only supports Java 17. Agora is on Java 11. See https://broadworkbench.atlassian.net/browse/AN-394
   "org.broadinstitute.dsde.workbench" % "sam-client_2.12" % "0.1-61135c7",      // Should become available for 2.13 once a release happens ( https://github.com/broadinstitute/sam/pull/491 )
   "org.broadinstitute.cromwell" % "cromwell-client_2.12" % "0.1-8b413b45f-SNAP", // Contains only Java, pinning on 2.12
   "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V excludeAll(

--- a/build.sbt
+++ b/build.sbt
@@ -89,8 +89,8 @@ libraryDependencies ++= Seq(
   "org.mock-server" % "mockserver-netty" % "5.11.1" % Test,
   "com.dimafeng" %% "testcontainers-scala-mysql" % testcontainersScalaV % Test,
   "com.dimafeng" %% "testcontainers-scala-mongodb" % testcontainersScalaV % Test,
-  "org.flywaydb" % "flyway-core" % "11.2.0" % Test,
-  "org.flywaydb" % "flyway-mysql" % "11.2.0" % Test,
+  "org.flywaydb" % "flyway-core" % "9.22.3" % Test, // Starting 10.0.0 Flyway only supports Java 17. Agora is on Java 11
+  "org.flywaydb" % "flyway-mysql" % "9.22.3" % Test,
   "org.broadinstitute.dsde.workbench" % "sam-client_2.12" % "0.1-61135c7",      // Should become available for 2.13 once a release happens ( https://github.com/broadinstitute/sam/pull/491 )
   "org.broadinstitute.cromwell" % "cromwell-client_2.12" % "0.1-8b413b45f-SNAP", // Contains only Java, pinning on 2.12
   "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V excludeAll(

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,8 @@ libraryDependencies ++= Seq(
   "org.mock-server" % "mockserver-netty" % "5.11.1" % Test,
   "com.dimafeng" %% "testcontainers-scala-mysql" % testcontainersScalaV % Test,
   "com.dimafeng" %% "testcontainers-scala-mongodb" % testcontainersScalaV % Test,
-  "org.flywaydb" % "flyway-core" % "7.3.2" % Test,
+  "org.flywaydb" % "flyway-core" % "11.2.0" % Test,
+  "org.flywaydb" % "flyway-mysql" % "11.2.0" % Test,
   "org.broadinstitute.dsde.workbench" % "sam-client_2.12" % "0.1-61135c7",      // Should become available for 2.13 once a release happens ( https://github.com/broadinstitute/sam/pull/491 )
   "org.broadinstitute.cromwell" % "cromwell-client_2.12" % "0.1-8b413b45f-SNAP", // Contains only Java, pinning on 2.12
   "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V excludeAll(

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -23,7 +23,7 @@ mockAuthenticatedUserEmail = "broadprometheustest@gmail.com"
 sqlDatabase = {
   profile = "slick.jdbc.MySQLProfile$"
   db {
-    url = "jdbc:tc:mysql:8.4.3:///agora"
+    url = "jdbc:tc:mysql:8.0.37:///agora"
     user = null
     password = null
     driver = "org.testcontainers.jdbc.ContainerDatabaseDriver"

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -23,7 +23,7 @@ mockAuthenticatedUserEmail = "broadprometheustest@gmail.com"
 sqlDatabase = {
   profile = "slick.jdbc.MySQLProfile$"
   db {
-    url = "jdbc:tc:mysql:8.0:///agora"
+    url = "jdbc:tc:mysql:8.4.3:///agora"
     user = null
     password = null
     driver = "org.testcontainers.jdbc.ContainerDatabaseDriver"

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -23,7 +23,7 @@ mockAuthenticatedUserEmail = "broadprometheustest@gmail.com"
 sqlDatabase = {
   profile = "slick.jdbc.MySQLProfile$"
   db {
-    url = "jdbc:tc:mysql:8.0.40:///agora"
+    url = "jdbc:tc:mysql:5.6.51:///agora"
     user = null
     password = null
     driver = "org.testcontainers.jdbc.ContainerDatabaseDriver"

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -23,7 +23,7 @@ mockAuthenticatedUserEmail = "broadprometheustest@gmail.com"
 sqlDatabase = {
   profile = "slick.jdbc.MySQLProfile$"
   db {
-    url = "jdbc:tc:mysql:8.0.37:///agora"
+    url = "jdbc:tc:mysql:8.0.40:///agora"
     user = null
     password = null
     driver = "org.testcontainers.jdbc.ContainerDatabaseDriver"

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -23,7 +23,7 @@ mockAuthenticatedUserEmail = "broadprometheustest@gmail.com"
 sqlDatabase = {
   profile = "slick.jdbc.MySQLProfile$"
   db {
-    url = "jdbc:tc:mysql:5.6.51:///agora"
+    url = "jdbc:tc:mysql:8.0.40:///agora"
     user = null
     password = null
     driver = "org.testcontainers.jdbc.ContainerDatabaseDriver"

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
@@ -1,7 +1,7 @@
 
 package org.broadinstitute.dsde.agora.server.dataaccess.permissions
 
-import org.broadinstitute.dsde.agora.server.{AgoraTestData, AgoraTestFixture}
+import org.broadinstitute.dsde.agora.server.{AgoraConfig, AgoraTestData, AgoraTestFixture}
 import org.broadinstitute.dsde.agora.server.dataaccess.permissions.AgoraPermissions._
 import org.broadinstitute.dsde.agora.server.webservice.ApiServiceSpec
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -10,12 +10,23 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 @DoNotDiscover
 class AgoraPermissionsSpec extends ApiServiceSpec with BeforeAndAfterAll with AgoraTestFixture with AnyFlatSpecLike {
 
+  import AgoraConfig.sqlDatabase.profile.api._
+
   override protected def beforeAll(): Unit = {
     ensureDatabasesAreRunning()
   }
 
   override protected def afterAll(): Unit = {
     clearDatabases()
+  }
+
+  "Agora" should "run on expected SQL version" in {
+    val action = for {
+      version <- sql"select version();".as[String]
+    } yield version.head
+    val version = runInDB { _ => action }
+
+    assert(version equals "8.4.3")
   }
 
   "Agora" should "return true if someone has read access and we ask if they have read access " in {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
@@ -26,7 +26,7 @@ class AgoraPermissionsSpec extends ApiServiceSpec with BeforeAndAfterAll with Ag
     } yield version.head
     val version = runInDB { _ => action }
 
-    assert(version equals "5.6.51")
+    assert(version equals "8.0.40")
   }
 
   "Agora" should "return true if someone has read access and we ask if they have read access " in {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
@@ -26,7 +26,7 @@ class AgoraPermissionsSpec extends ApiServiceSpec with BeforeAndAfterAll with Ag
     } yield version.head
     val version = runInDB { _ => action }
 
-    assert(version equals "8.0.40")
+    assert(version equals "5.6.51")
   }
 
   "Agora" should "return true if someone has read access and we ask if they have read access " in {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
@@ -26,7 +26,7 @@ class AgoraPermissionsSpec extends ApiServiceSpec with BeforeAndAfterAll with Ag
     } yield version.head
     val version = runInDB { _ => action }
 
-    assert(version equals "8.0.37")
+    assert(version equals "8.0.40")
   }
 
   "Agora" should "return true if someone has read access and we ask if they have read access " in {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/AgoraPermissionsSpec.scala
@@ -26,7 +26,7 @@ class AgoraPermissionsSpec extends ApiServiceSpec with BeforeAndAfterAll with Ag
     } yield version.head
     val version = runInDB { _ => action }
 
-    assert(version equals "8.4.3")
+    assert(version equals "8.0.37")
   }
 
   "Agora" should "return true if someone has read access and we ask if they have read access " in {

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/TestPermissionsClient.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/TestPermissionsClient.scala
@@ -19,7 +19,7 @@ object TestPermissionsClient {
       Set("url", "user", "password", "properties", "driver", "driverClassName"),
     )
 
-    Flyway.configure().dataSource(driverDataSource).cleanDisabled(false).load()
+    Flyway.configure().dataSource(driverDataSource).load()
   }
 
   def ensureRunning(): Unit = flyway.migrate()

--- a/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/TestPermissionsClient.scala
+++ b/src/test/scala/org/broadinstitute/dsde/agora/server/dataaccess/permissions/TestPermissionsClient.scala
@@ -19,7 +19,7 @@ object TestPermissionsClient {
       Set("url", "user", "password", "properties", "driver", "driverClassName"),
     )
 
-    Flyway.configure().dataSource(driverDataSource).load()
+    Flyway.configure().dataSource(driverDataSource).cleanDisabled(false).load()
   }
 
   def ensureRunning(): Unit = flyway.migrate()


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/AN-341

Flyway only supports until MySQL version 8.1. Upgrading Agora to 8.4.3 SQL version throws below warning. 
Reference: https://documentation.red-gate.com/flyway/reference/supported-databases/mysql
```
o.f.c.i.database.base.Database - Flyway upgrade recommended: MySQL 8.4 is newer than this version of Flyway and support has not been tested. The latest supported version of MySQL is 8.1.
```
Also, only Java 17 is supported starting Flyway version 10.0.0 and 8.1 is officially supported after this version. The tests were already using MySQL 8.0. This PR pins it to specific version i.e. 8.0.40.