### PR TITLE
AN-341 Replace obsolete Docker build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Production build/deploy/start of DSDE Methods Repository Webservice
 
-# TODO: adopt `sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.22_7_1.9.9_2.13.13`
-# Currently using the very outdated http://github.com/broadinstitute/scala-baseimage
-# because the Docker version on Jenkins is obsolete and does not support recent images.
-FROM broadinstitute/scala-baseimage as builder
+FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.22_7_1.9.9_2.13.13 as builder
 
 # Install Agora
 ADD . /agora


### PR DESCRIPTION
By porting [builds](https://github.com/broadinstitute/agora/actions/workflows/build_tag_publish.yml) to Github Actions, @salonishah11 unblocked my TODO from last fall!

The old `broadinstitute/scala-baseimage` image is unmaintained so there will not be a Java 17 version when we need it.